### PR TITLE
fix: cross-platform stability improvements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ const plugin = {
         betas:                  { type: ['string', 'array'], description: 'Custom beta headers' },
         enableAgentTeams:       { type: 'boolean', description: 'Enable experimental agent teams' },
         enableAutoMode:         { type: 'boolean', description: 'Enable auto permission mode' },
+        resumeSessionId:        { type: 'string', description: 'Resume an existing Claude Code session by its ID (e.g. from ~/.claude/sessions/). Replays conversation history via session/load instead of starting fresh.' },
       },
     },
     execute: async (_id, args) => {

--- a/src/persistent-session.ts
+++ b/src/persistent-session.ts
@@ -106,7 +106,16 @@ export class PersistentClaudeSession extends EventEmitter {
 
   // ─── Start ───────────────────────────────────────────────────────────────
 
-  async start(claudeBin = 'claude'): Promise<this> {
+  /**
+   * Resolve the claude binary path.
+   * Priority: explicit argument > CLAUDE_BIN env var > 'claude' default.
+   */
+  private static resolveBin(claudeBin?: string): string {
+    return claudeBin || process.env.CLAUDE_BIN || 'claude';
+  }
+
+  async start(claudeBin?: string): Promise<this> {
+    const resolvedBin = PersistentClaudeSession.resolveBin(claudeBin);
     const args = [
       '-p',
       '--input-format', 'stream-json',
@@ -124,8 +133,9 @@ export class PersistentClaudeSession extends EventEmitter {
     }
 
     // Resume / fork
-    if (this.options.claudeResumeId) {
-      args.push('--resume', this.options.claudeResumeId);
+    const resumeId = this.options.claudeResumeId || this.options.resumeSessionId;
+    if (resumeId) {
+      args.push('--resume', resumeId);
       if (this.options.forkSession) args.push('--fork-session');
     }
     if (this.options.customSessionId) args.push('--session-id', this.options.customSessionId);
@@ -210,9 +220,11 @@ export class PersistentClaudeSession extends EventEmitter {
     }
 
     // Build spawn environment
+    // Preserve the parent process PATH so the resolved binary and any PATH-relative
+    // tools (git, node, npm, etc.) remain accessible on all platforms and distros.
     const spawnEnv: NodeJS.ProcessEnv = {
       ...process.env,
-      PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin',
+      PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin',
     };
     if (this.options.baseUrl) spawnEnv.ANTHROPIC_BASE_URL = this.options.baseUrl;
     if (this.options.enableAgentTeams) spawnEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = 'true';
@@ -222,12 +234,14 @@ export class PersistentClaudeSession extends EventEmitter {
     }
 
     // Spawn
-    this.proc = spawn(claudeBin, args, {
+    this.proc = spawn(resolvedBin, args, {
       cwd: this.options.cwd,
       env: spawnEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: true,
     });
+    // Unref so the parent process can exit independently of the child.
+    this.proc.unref();
 
     // Parse stdout line-by-line
     const rl = readline.createInterface({ input: this.proc.stdout!, crlfDelay: Infinity });
@@ -261,8 +275,17 @@ export class PersistentClaudeSession extends EventEmitter {
       this.once('ready', () => { clearTimeout(timeout); resolve(this); });
       this.once('error', (err) => { clearTimeout(timeout); reject(err); });
 
-      // Claude doesn't send explicit ready signal
+      // Emit ready on the first `system` init event from the CLI.
+      // Fall back to a 2 s timer in case the CLI version doesn't emit one.
+      const onInit = () => {
+        if (!this._isReady) {
+          this._isReady = true;
+          this.emit('ready');
+        }
+      };
+      this.once('init', onInit);
       setTimeout(() => {
+        this.removeListener('init', onInit);
         if (!this._isReady) {
           this._isReady = true;
           this.emit('ready');
@@ -526,7 +549,12 @@ export class PersistentClaudeSession extends EventEmitter {
       isReady: this._isReady,
       startTime: this.stats.startTime,
       lastActivity: this.stats.lastActivity,
-      contextPercent: 0,
+      // Approximate: assumes a 200k-token context window.
+      // Claude Code doesn't expose exact context usage via the JSON protocol,
+      // so this is a best-effort estimate based on cumulative token counts.
+      contextPercent: Math.min(100, Math.round(
+        (this.stats.tokensIn + this.stats.tokensOut) / 200_000 * 100
+      )),
       sessionId: this.sessionId,
       uptime: this.stats.startTime
         ? Math.round((Date.now() - new Date(this.stats.startTime).getTime()) / 1000)

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface SessionConfig {
   customSessionId?: string;
   sessionName?: string;
   claudeResumeId?: string;
+  resumeSessionId?: string;
   forkSession?: boolean;
   // Directories
   addDir?: string[];


### PR DESCRIPTION
## Summary

A set of correctness and stability fixes targeting non-macOS environments and general robustness.

---

### Fixes

**1. Hard-coded macOS PATH breaks Linux / non-Homebrew environments** (`persistent-session.ts`)

The spawn environment overrode `PATH` with a hard-coded macOS-specific value:
```
/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
```
This silently drops any PATH entries set by the calling process (nvm, pyenv, custom installs, etc.) and causes `spawn` to fail on Linux or any system where the `claude` binary is not in those four directories.

**Fix:** inherit `process.env.PATH` and use the hard-coded string only as a last-resort fallback.

---

**2. No way to use a custom/alternative `claude` binary**

The binary path was resolved purely from the `claudeBin` argument with no environment-variable escape hatch.

**Fix:** introduce a `CLAUDE_BIN` environment variable. Resolution priority:
```
explicit arg  >  CLAUDE_BIN env var  >  "claude" default
```
Useful when the desired binary has a different name or lives outside PATH.

---

**3. Detached child process not unref'd — parent can't exit cleanly** (`persistent-session.ts`)

`spawn` is called with `detached: true` but `proc.unref()` was never called. This keeps a reference to the child in the Node.js event loop, preventing the parent process from exiting until the child terminates.

**Fix:** call `this.proc.unref()` immediately after `spawn`.

---

**4. `ready` event relies solely on a blind 2 s timeout** (`persistent-session.ts`)

The session was declared ready after a fixed 2-second delay regardless of whether the CLI had actually initialised. On slow machines or under load the process may not be ready yet; on fast machines the delay wastes time.

**Fix:** listen for the `init` event (emitted when the CLI sends a `system:init` JSON line) and emit `ready` immediately. The 2 s timer is kept as a fallback for CLI versions that do not emit a `system` event, but the listener is removed once the timer fires to avoid a double-emit.

---

### Features

**5. `contextPercent` always returned 0** (`persistent-session.ts`)

`getStats()` had `contextPercent: 0` hard-coded. The JSON streaming protocol does not expose the exact context window fill level, but a reasonable approximation can be computed from cumulative token counts.

**Fix:** return `min(100, round((tokensIn + tokensOut) / 200_000 * 100))`. The field is annotated in-source as an approximation.

---

**6. `resumeSessionId` not exposed in tool schema or types** (`types.ts`, `index.ts`)

`claudeResumeId` existed internally but was not surfaced in the public `SessionConfig` type or the `claude_session_start` tool parameters. Users had no documented way to resume a previous session.

**Fix:** add `resumeSessionId` as an alias (both are accepted; `claudeResumeId` continues to work for backward compatibility) and expose it in the tool schema with a description.

---

## Testing

- Verified spawn succeeds on Linux with nvm-managed Node where the previous PATH override would have hidden the binary.
- Verified `CLAUDE_BIN` override works end-to-end.
- Verified `contextPercent` returns a non-zero value after a turn with token usage.
- No breaking changes to existing behaviour or public API.
