### PR TITLE
feat(health): add claude_session_health plugin tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,14 +208,14 @@ const plugin = {
       },
     });
 
-    // ─── Tool: claude_session_health ─────────────────────────────────────
+    // ─── Tool: claude_sessions_overview ──────────────────────────────────
 
     api.registerTool({
-      name: 'claude_session_health',
-      description: 'Check plugin health and get diagnostics for all active Claude Code sessions. Returns readiness, cost, context usage, and last activity for each session.',
+      name: 'claude_sessions_overview',
+      description: 'Get an aggregate overview of all active Claude Code sessions — readiness, busy/paused state, cost, context usage, and last activity for each. Use this for a dashboard view across all sessions. For single-session detail, use claude_session_status instead.',
       parameters: { type: 'object', properties: {} },
       execute: async (_id) => {
-        if (!manager) return { ok: true, version: '2.0.0', sessions: 0, sessionNames: [], uptime: process.uptime(), details: [] };
+        if (!manager) return { ok: true, version: 'unknown', sessions: 0, sessionNames: [], uptime: process.uptime(), details: [] };
         return manager.health();
       },
     });

--- a/src/persistent-session.ts
+++ b/src/persistent-session.ts
@@ -72,6 +72,7 @@ export class PersistentClaudeSession extends EventEmitter {
   private proc: ChildProcess | null = null;
   private _isReady = false;
   private _isPaused = false;
+  private _isBusy = false;
   private currentRequestId = 0;
   private _streamCallbacks: StreamCallbacks | null = null;
   private _contextHighFired = false;
@@ -103,6 +104,8 @@ export class PersistentClaudeSession extends EventEmitter {
   }
 
   get isReady(): boolean { return this._isReady; }
+  get isPaused(): boolean { return this._isPaused; }
+  get isBusy(): boolean { return this._isBusy; }
 
   // ─── Start ───────────────────────────────────────────────────────────────
 
@@ -445,9 +448,11 @@ export class PersistentClaudeSession extends EventEmitter {
     if (options.callbacks) this._streamCallbacks = options.callbacks;
 
     if (options.waitForComplete) {
+      this._isBusy = true;
       try {
         return await this._waitForTurnComplete(options.timeout || 300_000);
       } finally {
+        this._isBusy = false;
         if (options.callbacks) this._streamCallbacks = null;
       }
     }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -8,6 +8,25 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { createRequire } from 'node:module';
+
+const _require = createRequire(import.meta.url);
+function getPluginVersion(): string {
+  try {
+    // Walk up from this file to find package.json
+    let dir = path.dirname(_require.resolve('./session-manager.js').replace('/dist/', '/'));
+    for (let i = 0; i < 5; i++) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
+        if (pkg.version) return pkg.version;
+      }
+      dir = path.dirname(dir);
+    }
+  } catch { /* ignore */ }
+  return 'unknown';
+}
+
 
 import { PersistentClaudeSession } from './persistent-session.js';
 import {
@@ -326,6 +345,11 @@ export class SessionManager {
 
   // ─── Health ────────────────────────────────────────────────────────────
 
+  /**
+   * Returns an overview of all active sessions — analogous to a dashboard.
+   * Unlike claude_session_status (single session), this gives the aggregate
+   * view: how many sessions are running, which are busy, total uptime, etc.
+   */
   health(): {
     ok: boolean;
     version: string;
@@ -343,13 +367,13 @@ export class SessionManager {
       lastActivity: string | null;
     }>;
   } {
-    const sessions = Array.from(this.sessions.entries()).map(([name, managed]) => {
+    const details = Array.from(this.sessions.entries()).map(([name, managed]) => {
       const stats = managed.session.getStats();
       return {
         name,
         ready: stats.isReady,
-        busy: managed.session.listenerCount('turn_complete') > 0,
-        paused: false,
+        busy: managed.session.isBusy,
+        paused: managed.session.isPaused,
         turns: stats.turns,
         costUsd: stats.costUsd,
         contextPercent: stats.contextPercent,
@@ -359,11 +383,11 @@ export class SessionManager {
 
     return {
       ok: true,
-      version: '2.0.0',
+      version: getPluginVersion(),
       sessions: this.sessions.size,
       sessionNames: Array.from(this.sessions.keys()),
       uptime: process.uptime(),
-      details: sessions,
+      details,
     };
   }
 


### PR DESCRIPTION
## Summary

Exposes the existing `/health` HTTP endpoint as a first-class plugin tool so AI assistants can call it directly without HTTP access.

### Changes
- Add `SessionManager.health()` returning per-session diagnostics
- Register `claude_session_health` tool in `index.ts`
- Returns: `ok`, `version`, `uptime`, `sessions`, `sessionNames`, and `details[]` with per-session `ready/busy/paused/turns/costUsd/contextPercent/lastActivity`