### PR TITLE
feat(dynamic-tools): runtime tool list and model switching via restart-with-resume

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -326,13 +326,14 @@ const plugin = {
 
     api.registerTool({
       name: 'claude_session_update_tools',
-      description: 'Update allowedTools or disallowedTools for a running session. Restarts the session process with --resume to apply the new tool constraints while preserving conversation history.',
+      description: 'Update allowedTools or disallowedTools for a running session. Restarts the session process with --resume to apply the new tool constraints while preserving conversation history. Rejects if the session is currently busy.',
       parameters: {
         type: 'object',
         properties: {
           name:             { type: 'string', description: 'Session name' },
-          allowedTools:     { type: 'array', items: { type: 'string' }, description: 'New allowedTools list' },
-          disallowedTools:  { type: 'array', items: { type: 'string' }, description: 'New disallowedTools list' },
+          allowedTools:     { type: 'array', items: { type: 'string' }, description: 'New allowedTools list (replaces existing, or merges if merge:true)' },
+          disallowedTools:  { type: 'array', items: { type: 'string' }, description: 'New disallowedTools list (replaces existing, or merges if merge:true)' },
+          removeTools:      { type: 'array', items: { type: 'string' }, description: 'Tools to remove from allowedTools/disallowedTools (applied after merge)' },
           merge:            { type: 'boolean', description: 'Merge with existing lists instead of replacing (default false)' },
         },
         required: ['name'],
@@ -341,6 +342,7 @@ const plugin = {
         const info = await getManager().updateTools(args.name as string, {
           allowedTools: args.allowedTools as string[] | undefined,
           disallowedTools: args.disallowedTools as string[] | undefined,
+          removeTools: args.removeTools as string[] | undefined,
           merge: args.merge as boolean | undefined,
         });
         return { ok: true, restarted: true, ...info };

--- a/src/persistent-session.ts
+++ b/src/persistent-session.ts
@@ -72,6 +72,7 @@ export class PersistentClaudeSession extends EventEmitter {
   private proc: ChildProcess | null = null;
   private _isReady = false;
   private _isPaused = false;
+  private _isBusy = false;
   private currentRequestId = 0;
   private _streamCallbacks: StreamCallbacks | null = null;
   private _contextHighFired = false;
@@ -103,6 +104,8 @@ export class PersistentClaudeSession extends EventEmitter {
   }
 
   get isReady(): boolean { return this._isReady; }
+  get isPaused(): boolean { return this._isPaused; }
+  get isBusy(): boolean { return this._isBusy; }
 
   // ─── Start ───────────────────────────────────────────────────────────────
 
@@ -445,9 +448,11 @@ export class PersistentClaudeSession extends EventEmitter {
     if (options.callbacks) this._streamCallbacks = options.callbacks;
 
     if (options.waitForComplete) {
+      this._isBusy = true;
       try {
         return await this._waitForTurnComplete(options.timeout || 300_000);
       } finally {
+        this._isBusy = false;
         if (options.callbacks) this._streamCallbacks = null;
       }
     }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -210,22 +210,52 @@ export class SessionManager {
   /**
    * Switch model immediately by restarting the session with --resume.
    * Conversation history is preserved via the claude session ID.
+   *
+   * Guards:
+   * - Rejects if session is currently processing a message (busy guard)
+   * - Validates model string against known aliases before restarting
+   * - Rolls back to old session if startSession fails
    */
   async switchModel(name: string, model: string): Promise<SessionInfo> {
     const managed = this._getSession(name);
+
+    // Busy guard — don't restart mid-message
+    if (managed.session.isBusy) {
+      throw new Error(`Session '${name}' is currently processing a message. Wait for it to finish before switching model.`);
+    }
+
     const sessionId = managed.claudeSessionId || managed.session.sessionId;
     if (!sessionId) throw new Error(`Session '${name}' has no claude session ID — cannot resume after restart`);
 
-    const oldConfig = managed.config;
+    // Validate model — must be a known alias or contain a recognisable pattern
+    const resolvedModel = this._resolveModel(model, managed.config.modelOverrides);
+    const knownPatterns = ['claude-', 'gemini-', 'gpt-', 'anthropic/', 'google/', 'openai/'];
+    const looksValid = knownPatterns.some(p => resolvedModel.includes(p));
+    if (!looksValid) {
+      throw new Error(`Unknown model '${model}' (resolved: '${resolvedModel}'). Use a known alias (opus, sonnet, haiku, gemini-pro, etc.) or a full provider/model string.`);
+    }
+
+    const oldConfig = { ...managed.config };
     managed.session.stop();
     this.sessions.delete(name);
 
-    return this.startSession({
-      ...oldConfig,
-      name,
-      model,
-      resumeSessionId: sessionId,
-    });
+    try {
+      return await this.startSession({
+        ...oldConfig,
+        name,
+        model,
+        resumeSessionId: sessionId,
+      });
+    } catch (err) {
+      // Rollback: restart with original config
+      console.error(`[SessionManager] switchModel failed for '${name}', attempting rollback:`, err);
+      try {
+        await this.startSession({ ...oldConfig, name, resumeSessionId: sessionId });
+      } catch (rollbackErr) {
+        console.error(`[SessionManager] Rollback also failed for '${name}':`, rollbackErr);
+      }
+      throw new Error(`Failed to switch model for '${name}': ${(err as Error).message}`);
+    }
   }
 
   /**
@@ -235,18 +265,31 @@ export class SessionManager {
    * the only way to apply new constraints is to restart the process with
    * the updated flags and --resume to replay conversation history.
    *
-   * This method stops the current process, merges the new tool config,
-   * and starts a fresh process in the same session context.
+   * Guards:
+   * - Rejects if session is busy
+   * - Rolls back to old session if startSession fails
+   * - merge:true adds tools; removeTools removes specific tools from the list
    */
   async updateTools(
     name: string,
-    opts: { allowedTools?: string[]; disallowedTools?: string[]; merge?: boolean },
+    opts: {
+      allowedTools?: string[];
+      disallowedTools?: string[];
+      removeTools?: string[];
+      merge?: boolean;
+    },
   ): Promise<SessionInfo> {
     const managed = this._getSession(name);
+
+    // Busy guard
+    if (managed.session.isBusy) {
+      throw new Error(`Session '${name}' is currently processing a message. Wait for it to finish before updating tools.`);
+    }
+
     const sessionId = managed.claudeSessionId || managed.session.sessionId;
     if (!sessionId) throw new Error(`Session '${name}' has no claude session ID — cannot resume after restart`);
 
-    const oldConfig = managed.config;
+    const oldConfig = { ...managed.config };
     let newAllowed = opts.allowedTools;
     let newDisallowed = opts.disallowedTools;
 
@@ -259,18 +302,33 @@ export class SessionManager {
         : oldConfig.disallowedTools;
     }
 
-    // Stop current process
+    // Remove specific tools if requested
+    if (opts.removeTools?.length) {
+      const removeSet = new Set(opts.removeTools);
+      if (newAllowed) newAllowed = newAllowed.filter(t => !removeSet.has(t));
+      if (newDisallowed) newDisallowed = newDisallowed.filter(t => !removeSet.has(t));
+    }
+
     managed.session.stop();
     this.sessions.delete(name);
 
-    // Restart with patched tool config + resume
-    return this.startSession({
-      ...oldConfig,
-      name,
-      allowedTools: newAllowed,
-      disallowedTools: newDisallowed,
-      resumeSessionId: sessionId,
-    });
+    try {
+      return await this.startSession({
+        ...oldConfig,
+        name,
+        allowedTools: newAllowed,
+        disallowedTools: newDisallowed,
+        resumeSessionId: sessionId,
+      });
+    } catch (err) {
+      console.error(`[SessionManager] updateTools failed for '${name}', attempting rollback:`, err);
+      try {
+        await this.startSession({ ...oldConfig, name, resumeSessionId: sessionId });
+      } catch (rollbackErr) {
+        console.error(`[SessionManager] Rollback also failed for '${name}':`, rollbackErr);
+      }
+      throw new Error(`Failed to update tools for '${name}': ${(err as Error).message}`);
+    }
   }
 
   getCost(name: string) {


### PR DESCRIPTION
## Summary

The claude CLI does not support changing `--allowed-tools` or `--model` while running. This PR implements a `restart-with-resume` pattern: stop the process, apply new config, restart with `--resume` to preserve conversation history.

### Changes
- `SessionManager.updateTools(name, {allowedTools, disallowedTools, merge})`: restart with new tool constraints
- `SessionManager.switchModel(name, model)`: restart with new model
- `setModel()` retained as config-only update (no restart)
- New tool `claude_session_update_tools`: wrapper for `updateTools()`
- New tool `claude_session_switch_model`: wrapper for `switchModel()`
- Both return `restarted: true` so callers know a process cycle occurred