### PR TITLE
fix: team_list/team_send must not assume native /team or @teammate (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.1] - 2026-04-29
+
+### Fixed
+- **`team_list` / `team_send` on Claude engine** — earlier code assumed Claude Code CLI exposed `/team` and `@teammate` as user-facing commands. They do not. `team_list` returned `Unknown command: /team` and `team_send` sent the message as plain prose with a stray `@name` prefix. Both tools now use the same engine-agnostic virtual-team layer (cross-session inbox routing) for every engine. Claude Code's native experimental Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, v2.1.32+) is an in-process TUI mechanism with no stdin-driven messaging surface, so a subprocess wrapper cannot drive it. Thanks @shendiid ([#48](https://github.com/Enderfga/openclaw-claude-code/issues/48))
+- Removed unused `TEAM_LIST_TIMEOUT_MS` and `TEAM_SEND_TIMEOUT_MS` constants
+- Updated README, SKILL.md, and `multi-engine.md` to describe the unified virtual-team behavior
+
 ## [2.14.0] - 2026-04-28
 
 ### Added — Claude Code CLI 2.1.121 sync

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ All engines are tested and verified in each release:
 
 ### Known Limitations
 
-- **Team tools** (`team_list`, `team_send`) work on all engines: Claude uses native agent teams; Codex/Gemini/Cursor use cross-session messaging as a virtual team layer
+- **Team tools** (`team_list`, `team_send`) work on all engines via cross-session inbox routing as a virtual team layer. Claude Code's native experimental Agent Teams is an in-process TUI mechanism and is not reachable from a subprocess wrapper
 - **Codex/Gemini/Cursor sessions** are one-shot per message (no persistent subprocess) — context is carried via working directory, not conversation history
 - **Custom engine** event parsing assumes stream-json NDJSON format compatible with Claude Code / Gemini / Cursor CLI output; CLIs with proprietary output formats may need a built-in engine instead
 - **Council consensus** requires agents to output an explicit `[CONSENSUS: YES/NO]` tag — loose phrasing will default to NO

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enderfga/openclaw-claude-code",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "OpenClaw plugin — full Claude Code SDK with session management, agent teams, multi-model proxy, and plan mode",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -147,8 +147,7 @@ claude_session_deliver_inbox({ name: "receiver" })
 
 ## Team Tools (All Engines)
 
-- **Claude**: native `/team` and `@teammate` commands
-- **Codex/Gemini/Cursor**: virtual teams via cross-session inbox routing
+All engines use the same virtual-team layer: cross-session inbox routing across active SessionManager sessions. (Claude Code's native experimental Agent Teams is in-process TUI only and not reachable from a subprocess wrapper.)
 
 ```javascript
 claude_team_list({ name: "myproject" })

--- a/skills/references/multi-engine.md
+++ b/skills/references/multi-engine.md
@@ -149,16 +149,18 @@ interface ISession {
 
 ## Team Tools Across Engines
 
-Team tools (`team_list`, `team_send`) work on all engines with engine-appropriate implementations:
+Team tools (`team_list`, `team_send`) operate on the same virtual-team layer for **every** engine: the "team" is the set of all active sessions managed by SessionManager.
 
 | Engine | `team_list` | `team_send` |
 |--------|------------|-------------|
-| Claude | Native `/team` command | Native `@teammate` command |
+| Claude | Lists other active SessionManager sessions | Routes via cross-session inbox |
 | Codex | Lists other active SessionManager sessions | Routes via cross-session inbox |
 | Gemini | Lists other active SessionManager sessions | Routes via cross-session inbox |
 | Cursor | Lists other active SessionManager sessions | Routes via cross-session inbox |
 
-For Codex, Gemini, and Cursor, the "team" is the set of all active sessions managed by SessionManager. Messages are delivered via the inbox system — idle sessions receive immediately, busy sessions queue for later delivery.
+Messages are delivered via the inbox system — idle sessions receive immediately, busy sessions queue for later delivery.
+
+> **Note:** Claude Code does have a native experimental "Agent Teams" feature (v2.1.32+, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), but it is an in-process TUI mechanism with no slash command or stdin-driven messaging — a subprocess wrapper cannot access its mailbox. Plugin team tools therefore use the engine-agnostic virtual team across the board.
 
 ## Proxy: Any Model via OpenClaw Gateway
 

--- a/src/__tests__/session-manager.test.ts
+++ b/src/__tests__/session-manager.test.ts
@@ -800,6 +800,55 @@ describe('SessionManager', () => {
     });
   });
 
+  // ─── Team tools (issue #48 regression guard) ────────────────────────────
+  // Claude Code CLI does not expose `/team` or `@teammate` syntax. team_list
+  // and team_send must use the virtual-team / inbox layer for every engine.
+
+  describe('teamList / teamSend (virtual team across all engines)', () => {
+    it('teamList returns virtual team list for claude engine (no /team command)', async () => {
+      await mgr.startSession({ name: 'lead', cwd: '/tmp', engine: 'claude' });
+      await mgr.startSession({ name: 'helper', cwd: '/tmp', engine: 'claude' });
+
+      const out = await mgr.teamList('lead');
+
+      expect(out).toContain('Virtual team');
+      expect(out).toContain('helper');
+      expect(out).toContain('claude');
+      // Critically, the caller's session must NOT have been sent the literal '/team' string
+      expect(mockSessions[0].sendCalls.find((c) => c.message === '/team')).toBeUndefined();
+    });
+
+    it('teamList omits the calling session and reports "No other active sessions" when alone', async () => {
+      await mgr.startSession({ name: 'solo', cwd: '/tmp', engine: 'claude' });
+      const out = await mgr.teamList('solo');
+      expect(out).toBe('No other active sessions');
+    });
+
+    it('teamSend routes via cross-session inbox for claude engine (no @teammate command)', async () => {
+      await mgr.startSession({ name: 'sender', cwd: '/tmp', engine: 'claude' });
+      await mgr.startSession({ name: 'receiver', cwd: '/tmp', engine: 'claude' });
+
+      const result = await mgr.teamSend('sender', 'receiver', 'please review');
+
+      // Sender must NOT have been sent a literal '@receiver ...' string
+      expect(
+        mockSessions[0].sendCalls.find((c) => typeof c.message === 'string' && c.message.startsWith('@')),
+      ).toBeUndefined();
+      // Receiver got a cross-session-message envelope instead
+      expect(mockSessions[1].sendCalls.length).toBe(1);
+      const msg = mockSessions[1].sendCalls[0].message as string;
+      expect(msg).toContain('<cross-session-message');
+      expect(msg).toContain('from="sender"');
+      expect(msg).toContain('please review');
+      expect(result.output).toContain('delivered');
+    });
+
+    it('teamSend throws clearly when teammate session does not exist', async () => {
+      await mgr.startSession({ name: 'lone', cwd: '/tmp', engine: 'claude' });
+      await expect(mgr.teamSend('lone', 'ghost', 'hi')).rejects.toThrow("Target session 'ghost' not found");
+    });
+  });
+
   // ─── Ultraplan ──────────────────────────────────────────────────────
 
   describe('ultraplan', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,10 +42,6 @@ export const INTER_ROUND_DELAY_MS = 3_000;
 export const EMPTY_RESPONSE_RETRY_DELAY_MS = 5_000;
 /** Timeout for council follow-up prompts */
 export const FOLLOWUP_TIMEOUT_MS = 60_000;
-/** Timeout for team list operations */
-export const TEAM_LIST_TIMEOUT_MS = 30_000;
-/** Timeout for team send operations */
-export const TEAM_SEND_TIMEOUT_MS = 120_000;
 /** Timeout for ultraplan sessions */
 export const ULTRAPLAN_TIMEOUT_MS = 1_800_000;
 /** How long completed results remain queryable */

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -152,8 +152,6 @@ import {
   CLEANUP_INTERVAL_MS,
   TURN_TIMEOUT_MS,
   GREP_HISTORY_FETCH,
-  TEAM_LIST_TIMEOUT_MS,
-  TEAM_SEND_TIMEOUT_MS,
   RESULT_TTL_MS,
   ULTRAPLAN_TIMEOUT_MS,
   ULTRAREVIEW_POLL_INTERVAL_MS,
@@ -741,16 +739,14 @@ export class SessionManager {
   // ─── Agent Teams ───────────────────────────────────────────────────────
 
   async teamList(name: string): Promise<string> {
-    const managed = this._getSession(name);
-    const engine = managed.config.engine || 'claude';
+    // Validate the calling session exists, but list all other sessions as virtual
+    // teammates regardless of engine. Claude Code's native Agent Teams (v2.1.32+,
+    // gated by CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS) is an in-process TUI
+    // mechanism — it has no `/team` slash command and no stdin-driven mailbox
+    // accessible to a subprocess wrapper. Earlier code assumed `/team` existed
+    // and got back `Unknown command: /team` (issue #48).
+    this._getSession(name);
 
-    // Claude: use native /team command
-    if (engine === 'claude') {
-      const result = await managed.session.send('/team', { waitForComplete: true, timeout: TEAM_LIST_TIMEOUT_MS });
-      return 'text' in result ? result.text : '';
-    }
-
-    // Codex/Gemini: list other active sessions as virtual teammates
     const teammates: string[] = [];
     for (const [sessionName, m] of this.sessions) {
       if (sessionName === name) continue;
@@ -766,23 +762,7 @@ export class SessionManager {
 
   async teamSend(name: string, teammate: string, message: string): Promise<SendResult> {
     const managed = this._getSession(name);
-    const engine = managed.config.engine || 'claude';
 
-    // Claude: use native @teammate command
-    if (engine === 'claude') {
-      managed.lastActivity = Date.now();
-      const result = await managed.session.send(`@${teammate} ${message}`, {
-        waitForComplete: true,
-        timeout: TEAM_SEND_TIMEOUT_MS,
-      });
-      return {
-        output: 'text' in result ? result.text : '',
-        sessionId: managed.claudeSessionId,
-        events: [],
-      };
-    }
-
-    // Codex/Gemini: route via cross-session messaging
     if (!this.sessions.has(teammate)) {
       throw new Error(`Target session '${teammate}' not found. Use team_list to see available sessions.`);
     }


### PR DESCRIPTION
## Summary

- Issue #48: `team_list` returned `Unknown command: /team` and `team_send` sent `@name <message>` as plain prose to Claude Code, because `/team` and `@teammate` are **not** Claude Code slash commands. They never were — Claude Code's native "Agent Teams" feature (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, v2.1.32+) is an in-process TUI mechanism with no stdin-driven messaging surface a subprocess wrapper can reach.
- Drop the `engine === 'claude'` branches in `teamList` / `teamSend` and route every engine through the existing virtual-team layer (cross-session inbox). Behavior is now uniform across Claude / Codex / Gemini / Cursor.
- Remove unused `TEAM_LIST_TIMEOUT_MS` / `TEAM_SEND_TIMEOUT_MS` constants.
- Add four regression tests covering the claude-engine path so this can't silently regress.
- Update README, SKILL.md, and `skills/references/multi-engine.md` to describe the unified behavior.
- Bump to 2.14.1.

Closes #48 — thanks @shendiid for the report.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` — 448/448 passing, including 4 new tests in `teamList / teamSend (virtual team across all engines)`:
  - `teamList returns virtual team list for claude engine (no /team command)`
  - `teamList omits the calling session and reports "No other active sessions" when alone`
  - `teamSend routes via cross-session inbox for claude engine (no @teammate command)`
  - `teamSend throws clearly when teammate session does not exist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)