### PR TITLE
feat(autoloop): correctness fixes + frozen reviewer memory + phase-error circuit (v3.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-05-11
+
+### Added — autoloop ergonomics & guardrails
+
+- **Reviewer frozen-memory injection.** `reviewer_memory.md` is now read at
+  Reviewer-session start and inlined as a `<frozen_memory_snapshot>` block in
+  the system prompt. The snapshot stays constant for the session's lifetime,
+  so the prefix cache hits on every iter; edits to the file on disk take
+  effect on the next Reviewer reset.
+- **Phase-error circuit breaker.** Consecutive `phase_error` messages
+  (subprocess deaths, failed `git commit`, etc.) count toward a configurable
+  threshold (`phaseErrorCircuit`, default `3`). When tripped, the runner
+  emits a `decision`-level push and auto-terminates with reason
+  `phase_error_circuit`. A successful `iter_done` resets the count.
+- **Stall detection.** A wall-clock timer fires `on_stall_30min` when the
+  runner has processed no messages for `stallMs` (default 30 min) while
+  `status === 'running'`. Configurable via `stallMs` /
+  `stallCheckIntervalMs`.
+- **`decisions.jsonl` audit trail.** `terminate`, `reset_agent`,
+  `update_push_policy`, `compact`, `spawn_subagents`, `phase_error`, and
+  rejected silence attempts write structured entries to
+  `<ledger>/decisions.jsonl`.
+- **`prior_metrics` history.** Runner keeps the last 20 verdict metrics and
+  passes the most recent 10 in every `review_request`, finally enabling the
+  Reviewer rubric's "metric improved but eval unchanged" check.
+- **Ledger `schema_version`.** `directive.json` / `eval_output.json` /
+  `verdict.json` now carry `schema_version: 1` for forward-compatible
+  migrations.
+
+### Fixed — autoloop correctness
+
+- **`state.iter` no longer pinned at `0`.** It advances by one per committed
+  `review_verdict`, so SSE events, `iter_done` payloads, push summaries and
+  ledger directories all point at the right iter. The dispatcher also bumps
+  the iter passed into Planner-tool handlers when responding to an
+  `iter_done(N)`, so follow-up directives correctly target iter `N+1`.
+- **`pause_loop` is enforced.** Previously a no-op; the runner now parks
+  agent-bound messages in a paused-buffer and replays them in order on
+  `resume`. `terminate` / runner-bound messages still process while paused.
+- **Coder / Reviewer subprocess death surfaces as `phase_error`.** A failed
+  `sendWithRecovery` retry used to masquerade as a "clarification request",
+  hiding the most common failure mode. A new `fatal` marker now flows into
+  a `phase_error` envelope and feeds the circuit.
+- **Reviewer sandbox restage preserves `reviewer_log.jsonl`.** The whitelist
+  also keeps the append-only audit log the Reviewer prompt has always
+  promised.
+- **Git commit failure inside an iter** (hook reject, signing missing) is
+  surfaced as `phase_error` instead of writing a stale `iter_artifacts`
+  with a phantom diff.
+- **Planner prompt drift.** Removed stale references to
+  `src/autoloop/v1/types.ts` (file does not exist) and the "S2 has no
+  `notify_user`" line that kept Planner from ever pushing the user.
+
+### Changed
+
+- **`update_push_policy` cannot silence `on_phase_error` or
+  `on_decision_needed`.** The `silent` flag is stripped (other fields on
+  the same rule still apply) and the attempt is recorded in
+  `decisions.jsonl`. Prevents a confused Planner from muting the
+  operator's lifeline channels.
+- **`firePolicyPush` self-drains** when called outside an active drain
+  (notably from the stall-detector interval), so policy pushes always
+  reach the notifier.
+- **`notify` reads recipient env vars at call time** rather than caching
+  them at module load — operators can rotate the env without restarting.
+
+### Tests
+
+- New `src/__tests__/autoloop-dispatcher.test.ts` (7 tests) covering
+  frozen-memory injection, phase_error surfacing, policy silencing guard,
+  sandbox whitelist, auto-compact + decisions.jsonl, ledger schema_version.
+- New `src/__tests__/autoloop-notify.test.ts` (5 tests) covering the
+  fallback chain (wechat → whatsapp → email), env-var gating, webchat
+  no-op, and `appendPushLog` formatting.
+- Extended `src/__tests__/autoloop-runner.test.ts` (16 tests, was 10)
+  with iter-advance, pause enforcement, phase-error circuit, prior_metrics
+  history, and stall detection.
+
 ## [3.5.6] - 2026-05-11
 
 ### Fixed — embedded HTTP server auth-by-default (closes #61)

--- a/configs/autoloop-planner-prompt.md
+++ b/configs/autoloop-planner-prompt.md
@@ -49,7 +49,7 @@ turn. Anything outside the blocks is shown to the user as your chat reply.
 
 **Rules:**
 - **Never call `spawn_subagents` without explicit user approval** in the chat. Even if the plan looks done, ask "ready to spawn subagents?" first and wait for "go" / "ok" / "开干" / similar. Exception: if `plan.md` frontmatter contains `auto_proceed: true`, you may spawn directly after writing the plan.
-- **Sanity-check the plan before spawning.** `plan.md` must have a Goal section, ≥1 gate, and a Constraints block. `goal.json` must validate against v1 GoalSpec (see `src/autoloop/v1/types.ts`).
+- **Sanity-check the plan before spawning.** `plan.md` must have a Goal section, ≥1 gate, and a Constraints block. `goal.json` must contain `scalar` (or explicit `null`), `gates`, and `termination` — see the goal.json shape example in `skills/references/autoloop.md` (§ `goal.json` shape).
 - **Do not emit raw JSON outside an `autoloop` fence.** Anything outside is shown to the user verbatim.
 - The user CAN see your reply — including questions, summaries, file references — but **cannot** see the autoloop blocks you emit. Don't restate every block in prose; only narrate when the action matters to the human.
 
@@ -96,9 +96,10 @@ turn. Anything outside the blocks is shown to the user as your chat reply.
     eval set unchanged, flag", "no new flags toggled silently">
    ```
 
-4. **Write goal.json** as the machine-readable mirror of the success criteria
-   — the same shape as v1's GoalSpec (see `src/autoloop/v1/types.ts`). The
-   runner will validate this when subagents are spawned.
+4. **Write goal.json** as the machine-readable mirror of the success criteria.
+   The shape is `{ scalar: { name, direction, extract_cmd, target } | null,
+   gates: [{ name, cmd, must }], termination: { max_iters, scalar_target_hit? } }`
+   — see the worked example in `skills/references/autoloop.md`.
 
 5. **Confirm with the user.** When you believe the plan is solid, say so
    plainly and ask "ready to spawn subagents?". Do **not** spawn them
@@ -120,14 +121,15 @@ turn. Anything outside the blocks is shown to the user as your chat reply.
 - ❌ Run the evaluator yourself. The Coder runs eval, the Reviewer audits it.
 - ❌ Promise outcomes ("this will get loss to 0.1"). State assumptions and
   gates instead.
-- ❌ Push the user out-of-band. In S2 there is no `notify_user` tool. Speak
-  through chat only.
+- ❌ Spam the user out-of-band. `notify_user` works, but the 5-minute dedup
+  doesn't make spam OK. Use it when something needs the user's attention
+  (decision, regression, stall, target hit), not for routine progress.
 
 ## Format
 
-Free-form chat is fine. If you need to emit something machine-readable for
-later phases, fence it as JSON in a labeled code block — but in S2 nothing
-parses your output for structured signals, so prefer prose.
+Free-form chat is fine. Autoloop control tools are parsed out of your reply
+as fenced ` ```autoloop ` JSON blocks (see the tool table above). Anything
+outside those blocks is shown to the user verbatim.
 
 ---
 

--- a/configs/autoloop-reviewer-prompt.md
+++ b/configs/autoloop-reviewer-prompt.md
@@ -9,8 +9,12 @@ independently verify whether each iteration actually moved toward the goal.
   that contains only the artifacts the orchestrator hands you for the iter
   under review — not the live workspace, not unrelated history.
 - You persist across iterations. Your accumulating mental model of "how
-  Coder cheats / cuts corners" is your most valuable asset. Save what you
-  learn into `reviewer_memory.md` after each review.
+  Coder cheats / cuts corners" is your most valuable asset. **The current
+  contents of `reviewer_memory.md` are injected as a frozen snapshot in
+  your system prompt at the start of this session**, so you do not need to
+  re-read the file each iter. Append fresh observations to it during
+  reviews; those edits become visible on the next Reviewer reset, not
+  mid-session.
 - You report only to the runner (which forwards your verdict to Planner).
   You do **not** chat with the user or with the Coder.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enderfga/claw-orchestrator",
-  "version": "3.5.6",
+  "version": "3.6.0",
   "description": "Claw Orchestrator — run Claude Code, Codex, Gemini, Cursor Agent, OpenCode and custom coding CLIs as one unified runtime for claw-style agent systems. Runs standalone, with first-class OpenClaw plugin support. Persistent sessions, multi-agent council, tool orchestration.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/skills/references/autoloop.md
+++ b/skills/references/autoloop.md
@@ -119,7 +119,60 @@ never see the JSON — only the Planner's narrative.
 5-minute dedup on (level, summary) prevents duplicate pushes from the same
 event. Channel chain: `auto` walks wechat → whatsapp → email; `wechat` /
 `webchat` / `email` route directly; `both` does webchat (if session known)
-+ wechat fallback chain.
++ wechat fallback chain. **`on_phase_error` and `on_decision_needed` cannot
+be set to `silent: true`** by Planner — `update_push_policy` strips the flag
+and records the attempt in `decisions.jsonl` (these channels are the
+operator's lifeline; they stay loud).
+
+## Auto-compact
+
+Each agent's context is monitored after every turn. When `getStats().contextPercent`
+crosses the per-agent threshold the dispatcher invokes `/compact` with a
+role-tuned hint (`compactSummaryFor`). Defaults: Planner 80 %, Coder 70 %,
+Reviewer 70 %. Override per run via `compactThresholds`. A 30 s debounce
+prevents re-fire while post-compact stats settle. Events: `compact` is
+emitted on the dispatcher EventEmitter AND appended to `decisions.jsonl`.
+
+## Phase-error circuit
+
+Subprocess deaths (Claude session lost), failed `git commit` in an iter, and
+other phase-bound failures surface as `phase_error` messages instead of
+silently masquerading as a "clarification request". The runner counts
+consecutive `phase_error`s and:
+
+1. Fires `on_phase_error` on each one (defaults to error / both channels).
+2. After `phaseErrorCircuit` consecutive errors (default **3**) emits a
+   `decision`-level push and an automatic `terminate { reason:
+   'phase_error_circuit' }`.
+
+A successful (non-error) `iter_done` resets the counter. Override the
+threshold via `AutoloopConfig.phaseErrorCircuit`.
+
+## Reviewer frozen memory
+
+`reviewer_memory.md` is read at Reviewer-session start and **injected as a
+frozen `<frozen_memory_snapshot>` block** into the system prompt. It stays
+constant for the lifetime of that session so Claude's prefix cache hits.
+Reviewer can append fresh observations to the file on disk; those edits
+become visible only on the next Reviewer reset (`autoloop_reset_agent`
+with `agent: 'reviewer', eager_restart: true`).
+
+## Decisions audit
+
+`<ledger>/decisions.jsonl` is the auditable trail of runner / dispatcher
+decisions:
+
+| Kind | When |
+|---|---|
+| `spawn_subagents` | Planner emits `spawn_subagents` |
+| `reset_agent` | Any agent reset (manual or auto-recovery) |
+| `compact` | Auto-compact fires |
+| `update_push_policy` | Planner mutates the policy |
+| `policy_silence_blocked` | Planner tried to silence a critical channel |
+| `phase_error` | Surfaced from dispatcher to runner |
+| `terminate` | Run ends (planner reason or `phase_error_circuit`) |
+
+JSONL, one entry per line, ts-prefixed.
 
 ## Ledger layout
 
@@ -128,22 +181,30 @@ event. Channel chain: `auto` walks wechat → whatsapp → email; `wechat` /
 ├── plan.md              # Planner-authored, git-committed
 ├── goal.json            # Planner-authored, git-committed
 ├── push_log.jsonl       # every notify_user attempt + channel used
+├── decisions.jsonl      # runner / dispatcher audit trail (see above)
 ├── reviewer_sandbox/    # Reviewer cwd; restaged per iter
 │   ├── plan.md          # copy
 │   ├── goal.json        # copy
 │   ├── iter-N/          # this iter's directive + diff + eval
 │   ├── prior_verdict.json
-│   └── reviewer_memory.md  # persistent across iters
+│   ├── reviewer_memory.md   # persistent (frozen-injected at session start)
+│   └── reviewer_log.jsonl   # persistent (Reviewer's append-only audit log)
 └── iter/<n>/
-    ├── directive.json     # Planner → Coder
-    ├── eval_output.json   # what Coder reported
+    ├── directive.json     # Planner → Coder        (schema_version: 1)
+    ├── eval_output.json   # what Coder reported     (schema_version: 1)
     ├── diff.patch         # git diff of the iter
-    ├── verdict.json       # Reviewer decision + audit notes
+    ├── verdict.json       # Reviewer decision + audit notes (schema_version: 1)
     └── coder_summary.txt
 ```
 
 The orchestrator git-commits each iter automatically. Coder must NOT call
-`git commit` itself — that confuses the diff log.
+`git commit` itself — that confuses the diff log. **If `git commit` fails
+inside an iter** (pre-commit hook reject, signing key missing, …) the
+dispatcher emits a `phase_error` instead of writing `iter_artifacts`, so
+the failure is visible to the runner and counts toward the circuit.
+
+Every JSON artifact in the ledger carries a `schema_version` field (currently
+`1`) to make future migrations explicit.
 
 ## Backend HTTP / SSE
 
@@ -210,9 +271,10 @@ iter 0 ledger artifacts (`directive` + `eval_output` + `diff.patch` +
 
 ## Known limitations
 
-- **No auto-compact on token budget.** Manual `autoloop_reset_agent` covers
-  the same recovery path. Auto-compact is queued for a follow-up once
-  `ISession.getStats` exposes token-usage hooks.
+- **`webchat` channel is a no-op** — `notifyUserFallbackChain` does not yet
+  carry a webchat session id at the run level, so `channel: 'webchat'`
+  always returns `channel_used: 'none'`. Use `auto` / `wechat` / `email`
+  until the inbound route lands.
 - **One-way push.** WeChat → Planner inbound replies are not yet wired (would
   need an openclaw-gateway tmux-passthrough route). Reply via webchat /
   `autoloop_chat`.
@@ -221,3 +283,10 @@ iter 0 ledger artifacts (`directive` + `eval_output` + `diff.patch` +
 - **No fork / population mode.** Single linear iter trajectory per run.
 - **Cross-run knowledge isolated.** Each run's `reviewer_memory.md` and
   `coder_notes.md` live in that run's ledger; no shared meta-store yet.
+- **No cost / wall-clock budget cap.** Only `phaseErrorCircuit` + Reviewer
+  hold/reject streaks bound the run; a steady-but-pointless ratchet could
+  run for days. Set `max_iters` in `goal.json` to bound iter count.
+- **Run state in memory.** SessionManager restart drops the live `autoloops`
+  map; the on-disk ledger survives but cannot resume a running state.
+- **Multi-run / same workspace** races on `git index.lock`. Run separate
+  workspaces (or git worktrees) for concurrent runs.

--- a/src/__tests__/autoloop-dispatcher.test.ts
+++ b/src/__tests__/autoloop-dispatcher.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for ClaudeAgentDispatcher — the layer between the runner's message
+ * bus and the real persistent Claude sessions. We stub SessionManager so the
+ * tests stay hermetic; only behaviour owned by the dispatcher (frozen-memory
+ * injection, sandbox staging, send-failure surfacing, decisions audit, policy
+ * silencing guard) is exercised.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { ClaudeAgentDispatcher } from '../autoloop/dispatcher.js';
+import { Msg } from '../autoloop/messages.js';
+import type { SessionManager } from '../session-manager.js';
+import type { PushPolicy } from '../autoloop/types.js';
+import { DEFAULT_PUSH_POLICY, LEDGER_SCHEMA_VERSION } from '../autoloop/types.js';
+
+interface StubCalls {
+  startSession: ReturnType<typeof vi.fn>;
+  sendMessage: ReturnType<typeof vi.fn>;
+  stopSession: ReturnType<typeof vi.fn>;
+  getStatus: ReturnType<typeof vi.fn>;
+  compactSession: ReturnType<typeof vi.fn>;
+}
+
+function makeStubManager(
+  opts: {
+    sendOutput?: string;
+    sendThrows?: number;
+    contextPercent?: number;
+  } = {},
+): { manager: SessionManager; calls: StubCalls } {
+  let throwsRemaining = opts.sendThrows ?? 0;
+  const calls: StubCalls = {
+    startSession: vi.fn(async () => ({ name: 'x', state: 'ready' })),
+    sendMessage: vi.fn(async () => {
+      if (throwsRemaining > 0) {
+        throwsRemaining -= 1;
+        throw new Error('subprocess died');
+      }
+      return { output: opts.sendOutput ?? '', error: undefined };
+    }),
+    stopSession: vi.fn(async () => undefined),
+    getStatus: vi.fn(() => ({
+      stats: { contextPercent: opts.contextPercent ?? 10, tokensIn: 0, tokensOut: 0, cachedTokens: 0 },
+    })),
+    compactSession: vi.fn(async () => undefined),
+  };
+  const manager = {
+    startSession: calls.startSession,
+    sendMessage: calls.sendMessage,
+    stopSession: calls.stopSession,
+    getStatus: calls.getStatus,
+    compactSession: calls.compactSession,
+  } as unknown as SessionManager;
+  return { manager, calls };
+}
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'autoloop-disp-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeDispatcher(
+  overrides: Partial<ConstructorParameters<typeof ClaudeAgentDispatcher>[0]> = {},
+  managerOpts?: Parameters<typeof makeStubManager>[0],
+): {
+  dispatcher: ClaudeAgentDispatcher;
+  calls: StubCalls;
+  ledgerDir: string;
+  workspace: string;
+} {
+  const { manager, calls } = makeStubManager(managerOpts);
+  const workspace = tmpRoot;
+  const dispatcher = new ClaudeAgentDispatcher({
+    manager,
+    runId: 'r1',
+    workspace,
+    ...overrides,
+  });
+  const ledgerDir = path.join(workspace, 'tasks', 'r1');
+  return { dispatcher, calls, ledgerDir, workspace };
+}
+
+describe('ClaudeAgentDispatcher — frozen reviewer memory', () => {
+  it('injects reviewer_memory.md contents into the Reviewer system prompt at startSession', async () => {
+    const { dispatcher, calls, ledgerDir } = makeDispatcher();
+    const sandbox = path.join(ledgerDir, 'reviewer_sandbox');
+    fs.mkdirSync(sandbox, { recursive: true });
+    fs.writeFileSync(path.join(sandbox, 'reviewer_memory.md'), 'Pattern: ZEBRA_OFFSET = sentinel\n');
+
+    await dispatcher.spawnSubagents();
+
+    // Reviewer is the second startSession call (after Coder).
+    const reviewerStart = calls.startSession.mock.calls.find(
+      (c) => (c[0] as { name: string }).name === 'autoloop-r1-reviewer',
+    );
+    expect(reviewerStart).toBeDefined();
+    const sp = (reviewerStart![0] as { systemPrompt: string }).systemPrompt;
+    expect(sp).toContain('<frozen_memory_snapshot>');
+    expect(sp).toContain('Pattern: ZEBRA_OFFSET = sentinel');
+  });
+
+  it('omits the frozen snapshot tag when reviewer_memory.md is missing', async () => {
+    const { dispatcher, calls } = makeDispatcher();
+    await dispatcher.spawnSubagents();
+    const reviewerStart = calls.startSession.mock.calls.find(
+      (c) => (c[0] as { name: string }).name === 'autoloop-r1-reviewer',
+    );
+    const sp = (reviewerStart![0] as { systemPrompt: string }).systemPrompt;
+    expect(sp).not.toContain('<frozen_memory_snapshot>');
+  });
+});
+
+describe('ClaudeAgentDispatcher — phase_error surfacing', () => {
+  it('returns a phase_error envelope (not a fake directive_ack) when Coder send fails twice', async () => {
+    const { dispatcher } = makeDispatcher({}, { sendThrows: 2 });
+    await dispatcher.spawnSubagents();
+    const replies = await dispatcher.deliver(
+      Msg.directive(0, { goal: 'g', constraints: [], success_criteria: [], max_attempts: 1 }),
+    );
+    expect(replies).toHaveLength(1);
+    expect(replies[0].type).toBe('phase_error');
+    if (replies[0].type === 'phase_error') {
+      expect(replies[0].payload.agent).toBe('coder');
+      expect(replies[0].payload.phase).toBe('send');
+    }
+  });
+});
+
+describe('ClaudeAgentDispatcher — updatePushPolicy guard', () => {
+  it('strips silent=true from on_phase_error / on_decision_needed but applies other fields', async () => {
+    const policyRef: PushPolicy = JSON.parse(JSON.stringify(DEFAULT_PUSH_POLICY));
+    const reply = `OK
+\`\`\`autoloop
+{"tool": "update_push_policy", "args": {"on_phase_error": {"silent": true, "channel": "email"}, "on_target_hit": {"silent": true}}}
+\`\`\`
+`;
+    const { dispatcher, ledgerDir } = makeDispatcher({ pushPolicyRef: policyRef }, { sendOutput: reply });
+    await dispatcher.deliver(Msg.chat(0, { text: 'hi' }));
+
+    // on_phase_error: silent stripped, channel applied.
+    expect(policyRef.on_phase_error.silent).not.toBe(true);
+    expect(policyRef.on_phase_error.channel).toBe('email');
+    // on_target_hit is not critical → silence honoured.
+    expect(policyRef.on_target_hit.silent).toBe(true);
+
+    // decisions.jsonl should record both the block + the merge.
+    const decisionsPath = path.join(ledgerDir, 'decisions.jsonl');
+    expect(fs.existsSync(decisionsPath)).toBe(true);
+    const lines = fs
+      .readFileSync(decisionsPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
+    expect(lines.some((l) => l.kind === 'policy_silence_blocked')).toBe(true);
+    expect(lines.some((l) => l.kind === 'update_push_policy')).toBe(true);
+  });
+});
+
+describe('ClaudeAgentDispatcher — stageReviewSandbox whitelist', () => {
+  it('preserves reviewer_memory.md AND reviewer_log.jsonl across iters', async () => {
+    const { dispatcher, ledgerDir } = makeDispatcher();
+    await dispatcher.spawnSubagents();
+    const sandbox = path.join(ledgerDir, 'reviewer_sandbox');
+    fs.writeFileSync(path.join(sandbox, 'reviewer_memory.md'), 'memory');
+    fs.writeFileSync(path.join(sandbox, 'reviewer_log.jsonl'), '{"a":1}\n');
+    fs.writeFileSync(path.join(sandbox, 'scratch.txt'), 'temp');
+    // Plant an iter dir so stageReviewSandbox can copy from it.
+    const iterDir = path.join(ledgerDir, 'iter', '0');
+    fs.mkdirSync(iterDir, { recursive: true });
+    fs.writeFileSync(path.join(iterDir, 'directive.json'), '{}');
+
+    // Reviewer needs to actually emit a review_complete or we'll observe a
+    // 'hold' fallback. We just stub sendOutput to include a valid block.
+    // Easier: directly call the private method via type assertion.
+    (dispatcher as unknown as { stageReviewSandbox(iter: number): void }).stageReviewSandbox(0);
+
+    expect(fs.existsSync(path.join(sandbox, 'reviewer_memory.md'))).toBe(true);
+    expect(fs.existsSync(path.join(sandbox, 'reviewer_log.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(sandbox, 'scratch.txt'))).toBe(false);
+  });
+});
+
+describe('ClaudeAgentDispatcher — auto-compact', () => {
+  it('fires compact + writes decisions.jsonl when contextPercent crosses threshold', async () => {
+    const { dispatcher, calls, ledgerDir } = makeDispatcher(
+      { compactThresholds: { planner: 50 } },
+      { contextPercent: 90, sendOutput: 'no autoloop blocks here' },
+    );
+
+    await dispatcher.deliver(Msg.chat(0, { text: 'hi' }));
+
+    expect(calls.compactSession).toHaveBeenCalledTimes(1);
+    const decisionsPath = path.join(ledgerDir, 'decisions.jsonl');
+    const lines = fs
+      .readFileSync(decisionsPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
+    const compactEntry = lines.find((l) => l.kind === 'compact');
+    expect(compactEntry).toBeDefined();
+    expect(compactEntry.payload.agent).toBe('planner');
+  });
+});
+
+describe('ClaudeAgentDispatcher — ledger schema_version', () => {
+  it('stamps schema_version on directive.json', async () => {
+    const { dispatcher, calls, ledgerDir } = makeDispatcher({}, { sendOutput: 'no blocks' });
+    await dispatcher.spawnSubagents();
+    void calls; // unused
+    await dispatcher.deliver(Msg.directive(0, { goal: 'g', constraints: [], success_criteria: [], max_attempts: 1 }));
+    const written = JSON.parse(fs.readFileSync(path.join(ledgerDir, 'iter', '0', 'directive.json'), 'utf-8'));
+    expect(written.schema_version).toBe(LEDGER_SCHEMA_VERSION);
+  });
+});

--- a/src/__tests__/autoloop-notify.test.ts
+++ b/src/__tests__/autoloop-notify.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the autoloop notify fallback chain and JSONL log.
+ *
+ * Strategy: stub `node:child_process.spawn` so we don't actually shell out to
+ * openclaw or send any messages. The tests assert which channel the chain
+ * picks given different env-var / exit-code combinations.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('node:child_process', () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
+
+import * as child_process from 'node:child_process';
+import { notifyUserFallbackChain, appendPushLog } from '../autoloop/notify.js';
+
+interface SpawnCall {
+  argv: string[];
+}
+const spawnCalls: SpawnCall[] = [];
+
+function mockChildResult(opts: { exitCode: number; stdout?: string; stderr?: string }): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { write: () => void; end: () => void };
+  kill: () => void;
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: () => void; end: () => void };
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = { write: () => undefined, end: () => undefined };
+  child.kill = () => undefined;
+  process.nextTick(() => {
+    if (opts.stdout) child.stdout.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr) child.stderr.emit('data', Buffer.from(opts.stderr));
+    child.emit('exit', opts.exitCode);
+  });
+  return child;
+}
+
+function setSpawnSequence(results: Array<{ exitCode: number; stdout?: string; stderr?: string }>): void {
+  let idx = 0;
+  (child_process.spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation((cmd: string, args: string[]) => {
+    spawnCalls.push({ argv: [cmd, ...args] });
+    const r = results[idx] ?? { exitCode: 127 };
+    idx += 1;
+    return mockChildResult(r);
+  });
+}
+
+const savedEnv = { ...process.env };
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+  (child_process.spawn as unknown as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+});
+
+describe('notifyUserFallbackChain', () => {
+  it('returns "none" when no channel env vars are set', async () => {
+    delete process.env.AUTOLOOP_WECHAT_RECIPIENT;
+    delete process.env.AUTOLOOP_WECHAT_ACCOUNT;
+    delete process.env.AUTOLOOP_WHATSAPP_RECIPIENT;
+    setSpawnSequence([]); // nothing should spawn
+    const r = await notifyUserFallbackChain({ level: 'info', summary: 'x', channel: 'auto' });
+    // Email script may or may not exist on the machine; allow either none or email.
+    expect(['none', 'email']).toContain(r.channel_used);
+  });
+
+  it('chooses wechat when env is set and openclaw returns the success marker', async () => {
+    process.env.AUTOLOOP_WECHAT_RECIPIENT = 'fake-id';
+    process.env.AUTOLOOP_WECHAT_ACCOUNT = 'fake-account';
+    setSpawnSequence([{ exitCode: 0, stdout: '✅ Sent\n' }]);
+    const r = await notifyUserFallbackChain({ level: 'info', summary: 'x', channel: 'auto' });
+    expect(r.channel_used).toBe('wechat');
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].argv[0]).toBe('openclaw');
+    expect(spawnCalls[0].argv).toContain('openclaw-weixin');
+  });
+
+  it('falls back to whatsapp when wechat fails', async () => {
+    process.env.AUTOLOOP_WECHAT_RECIPIENT = 'fake-id';
+    process.env.AUTOLOOP_WECHAT_ACCOUNT = 'fake-account';
+    process.env.AUTOLOOP_WHATSAPP_RECIPIENT = 'fake-wa';
+    setSpawnSequence([
+      { exitCode: 1, stderr: 'wechat down' },
+      { exitCode: 0, stdout: '✅ Sent\n' },
+    ]);
+    const r = await notifyUserFallbackChain({ level: 'warn', summary: 'y', channel: 'auto' });
+    expect(r.channel_used).toBe('whatsapp');
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls[1].argv).toContain('whatsapp');
+  });
+
+  it('webchat channel is a no-op (returns none) — kept for forward-compat', async () => {
+    const r = await notifyUserFallbackChain({ level: 'info', summary: 'x', channel: 'webchat' });
+    expect(r.channel_used).toBe('none');
+    expect(spawnCalls).toHaveLength(0);
+  });
+});
+
+describe('appendPushLog', () => {
+  it('appends one JSONL row per call', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'autoloop-pushlog-'));
+    try {
+      appendPushLog(dir, {
+        ts: '2026-01-01T00:00:00Z',
+        level: 'info',
+        summary: 's1',
+        channel_requested: 'auto',
+        channel_used: 'wechat',
+      });
+      appendPushLog(dir, {
+        ts: '2026-01-01T00:00:01Z',
+        level: 'warn',
+        summary: 's2',
+        channel_requested: 'wechat',
+        channel_used: 'none',
+      });
+      const lines = fs
+        .readFileSync(path.join(dir, 'push_log.jsonl'), 'utf-8')
+        .trim()
+        .split('\n')
+        .map((l) => JSON.parse(l));
+      expect(lines).toHaveLength(2);
+      expect(lines[0].summary).toBe('s1');
+      expect(lines[1].channel_used).toBe('none');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/autoloop-runner.test.ts
+++ b/src/__tests__/autoloop-runner.test.ts
@@ -5,7 +5,7 @@
  * drive the runner through a representative iter and assert routing invariants.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   type AnyAutoloopMessage,
   AutoloopRoutingError,
@@ -20,6 +20,7 @@ import type { AgentDispatcher, AutoloopConfig } from '../autoloop/types.js';
 function makeRunner(
   dispatcher: AgentDispatcher,
   recordedPushes: AnyAutoloopMessage[] = [],
+  overrides: Partial<AutoloopConfig> = {},
 ): {
   runner: AutoloopRunner;
   pushes: Array<{ level: string; summary: string }>;
@@ -34,8 +35,12 @@ function makeRunner(
       void recordedPushes;
     },
     dispatcher,
+    // Disable the real interval timer in tests by default.
+    stallCheckIntervalMs: 24 * 60 * 60 * 1000,
+    ...overrides,
   };
-  return { runner: new AutoloopRunner(config), pushes };
+  const runner = new AutoloopRunner(config);
+  return { runner, pushes };
 }
 
 describe('autoloop messages', () => {
@@ -85,6 +90,10 @@ describe('autoloop messages', () => {
 });
 
 describe('AutoloopRunner', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('drains a full iter: chat → directive → ack → artifacts → verdict → iter_done', async () => {
     const observed: string[] = [];
 
@@ -212,6 +221,164 @@ describe('AutoloopRunner', () => {
     // After 2 holds, on_reviewer_reject_2 should fire.
     const rejectPush = pushes.find((p) => p.summary.includes('on_reviewer_reject_2'));
     expect(rejectPush).toBeDefined();
+  });
+
+  it('state.iter advances after each iter_done', async () => {
+    let directiveCount = 0;
+    const dispatcher: AgentDispatcher = {
+      async deliver(env) {
+        if (env.type === 'chat' || env.type === 'iter_done') {
+          if (directiveCount >= 2) return [];
+          // Mock Planner picks the next iter by advancing past the iter_done's
+          // iter (matches the production dispatcher's iter-bump logic).
+          const nextIter = env.type === 'iter_done' ? env.iter + 1 : 0;
+          directiveCount += 1;
+          return [Msg.directive(nextIter, { goal: 'g', constraints: [], success_criteria: [], max_attempts: 1 })];
+        }
+        if (env.type === 'directive') {
+          return [Msg.iterArtifacts(env.iter, { diff: '', eval_output: {}, files_changed: [] })];
+        }
+        if (env.type === 'review_request') {
+          return [Msg.reviewVerdict(env.iter, { decision: 'advance', metric: 0.5, audit_notes: 'ok' })];
+        }
+        return [];
+      },
+    };
+    const { runner } = makeRunner(dispatcher);
+    await runner.start();
+    expect(runner.state.iter).toBe(0);
+    await runner.chat('go');
+    // After two iters of advance verdicts, state.iter should have advanced
+    // from 0 → 1 → 2.
+    expect(runner.state.iter).toBe(2);
+    runner.stop();
+  });
+
+  it('pause parks agent-bound messages and resume replays them in order', async () => {
+    const delivered: string[] = [];
+    const dispatcher: AgentDispatcher = {
+      async deliver(env) {
+        delivered.push(env.type);
+        return [];
+      },
+    };
+    const { runner } = makeRunner(dispatcher);
+    await runner.start();
+    runner.markSubagentsSpawned();
+
+    await runner.send(Msg.pause(0, { reason: 'manual' }));
+    expect(runner.state.status).toBe('paused');
+
+    // While paused, agent-bound messages park.
+    await runner.send(Msg.directive(0, { goal: 'g', constraints: [], success_criteria: [], max_attempts: 1 }));
+    expect(delivered).toEqual([]);
+
+    // Resume: parked messages drain in arrival order.
+    await runner.send(Msg.resume(0));
+    expect(runner.state.status).toBe('running');
+    expect(delivered).toEqual(['directive']);
+    runner.stop();
+  });
+
+  it('phase_error trips circuit after threshold (default 3) → auto-terminate', async () => {
+    const dispatcher: AgentDispatcher = {
+      async deliver() {
+        return [];
+      },
+    };
+    const { runner, pushes } = makeRunner(dispatcher, [], { phaseErrorCircuit: 3 });
+    await runner.start();
+
+    let terminatedReason: string | null = null;
+    runner.on('terminated', (r) => (terminatedReason = r));
+
+    for (let i = 0; i < 3; i++) {
+      await runner.send(Msg.phaseError(0, { agent: 'coder', phase: 'send', error: `boom ${i}` }));
+    }
+    expect(runner.state.status).toBe('terminated');
+    expect(terminatedReason).toBe('phase_error_circuit');
+    expect(runner.state.consecutive_phase_errors).toBe(3);
+    // A decision-level push should be emitted before terminate.
+    const decisionPush = pushes.find((p) => p.level === 'decision' && p.summary.includes('phase-error circuit'));
+    expect(decisionPush).toBeDefined();
+    // An on_phase_error policy push fires for each error too.
+    const errorPushes = pushes.filter((p) => p.summary.includes('on_phase_error'));
+    expect(errorPushes.length).toBeGreaterThanOrEqual(1); // dedup may collapse to 1
+    runner.stop();
+  });
+
+  it('successful iter_done resets consecutive_phase_errors', async () => {
+    const dispatcher: AgentDispatcher = {
+      async deliver() {
+        return [];
+      },
+    };
+    const { runner } = makeRunner(dispatcher, [], { phaseErrorCircuit: 5 });
+    await runner.start();
+
+    await runner.send(Msg.phaseError(0, { agent: 'coder', phase: 'send', error: 'x' }));
+    expect(runner.state.consecutive_phase_errors).toBe(1);
+
+    // Drive an advance verdict through the runner inbox.
+    await runner.send(Msg.iterArtifacts(0, { diff: '', eval_output: {}, files_changed: [] }));
+    await runner.send(Msg.reviewVerdict(0, { decision: 'advance', metric: 0.7, audit_notes: 'ok' }));
+    expect(runner.state.consecutive_phase_errors).toBe(0);
+    expect(runner.state.recent_phase_errors).toEqual([]);
+    runner.stop();
+  });
+
+  it('prior_metrics accumulates from verdict metrics across iters', async () => {
+    const requests: Array<number[]> = [];
+    const dispatcher: AgentDispatcher = {
+      async deliver(env) {
+        if (env.type === 'review_request') {
+          requests.push([...(env.payload.prior_metrics ?? [])]);
+          return [];
+        }
+        return [];
+      },
+    };
+    const { runner } = makeRunner(dispatcher);
+    await runner.start();
+
+    // Iter 0 verdict (metric 0.1)
+    await runner.send(Msg.iterArtifacts(0, { diff: '', eval_output: {}, files_changed: [] }));
+    await runner.send(Msg.reviewVerdict(0, { decision: 'advance', metric: 0.1, audit_notes: '' }));
+    // Iter 1 verdict (metric 0.3)
+    await runner.send(Msg.iterArtifacts(1, { diff: '', eval_output: {}, files_changed: [] }));
+    await runner.send(Msg.reviewVerdict(1, { decision: 'advance', metric: 0.3, audit_notes: '' }));
+    // Iter 2 review_request should observe both prior metrics.
+    await runner.send(Msg.iterArtifacts(2, { diff: '', eval_output: {}, files_changed: [] }));
+
+    expect(requests).toHaveLength(3);
+    expect(requests[0]).toEqual([]); // before any verdict
+    expect(requests[1]).toEqual([0.1]); // after iter 0
+    expect(requests[2]).toEqual([0.1, 0.3]); // after iter 1
+    runner.stop();
+  });
+
+  it('stall detector fires on_stall_30min when idle past stallMs', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const dispatcher: AgentDispatcher = {
+      async deliver() {
+        return [];
+      },
+    };
+    const { runner, pushes } = makeRunner(dispatcher, [], {
+      stallMs: 1000,
+      stallCheckIntervalMs: 100,
+    });
+    await runner.start();
+    runner.markSubagentsSpawned();
+    // Advance fake clock past stallMs so the interval observes a stalled run.
+    await vi.advanceTimersByTimeAsync(1500);
+    // Flush queued microtasks (firePolicyPush is async).
+    await vi.advanceTimersByTimeAsync(0);
+    const stallPush = pushes.find((p) => p.summary.includes('on_stall_30min'));
+    expect(stallPush).toBeDefined();
+    runner.stop();
+    vi.useRealTimers();
   });
 
   it('rejects invalid envelopes via validateMessage', async () => {

--- a/src/autoloop/dispatcher.ts
+++ b/src/autoloop/dispatcher.ts
@@ -29,7 +29,7 @@ import type { Logger } from '../logger.js';
 import { nullLogger } from '../logger.js';
 import { spawn } from 'node:child_process';
 import { type AnyAutoloopMessage, Msg } from './messages.js';
-import type { AgentDispatcher, AutoloopState, PushPolicy } from './types.js';
+import { LEDGER_SCHEMA_VERSION, type AgentDispatcher, type AutoloopState, type PushPolicy } from './types.js';
 import {
   applyPlannerToolCalls,
   parsePlannerReply,
@@ -37,6 +37,21 @@ import {
   type SpawnSubagentsArgs,
 } from './planner-tools.js';
 import { extractIterComplete, extractReviewComplete, parseAgentReply } from './agent-tools.js';
+
+/**
+ * Files inside <ledger>/reviewer_sandbox/ that survive `stageReviewSandbox`.
+ * Anything not listed is wiped between iters. `reviewer_memory.md` is also
+ * frozen-injected into the Reviewer system prompt at session start, so
+ * mid-session edits won't be reread until the next reset.
+ */
+const REVIEWER_SANDBOX_PERSIST = new Set(['reviewer_memory.md', 'reviewer_log.jsonl']);
+
+/**
+ * Push-policy keys that callers MUST NOT be able to silence at runtime.
+ * Prompt-injection could otherwise let a confused/malicious Planner mute the
+ * channels we use to surface phase errors and decision points.
+ */
+const UNSILENCEABLE_POLICY_KEYS = new Set(['on_phase_error', 'on_decision_needed']);
 
 export interface ClaudeAgentDispatcherConfig {
   manager: SessionManager;
@@ -94,6 +109,22 @@ const resolveDefaultReviewerPrompt = (): string => resolveConfigByName('autoloop
 interface SendMessageResult {
   output: string;
   error?: string;
+  /** Set when even the recovery retry failed — caller surfaces as phase_error. */
+  fatal?: boolean;
+}
+
+interface DecisionLogEntry {
+  ts: string;
+  kind:
+    | 'terminate'
+    | 'reset_agent'
+    | 'update_push_policy'
+    | 'compact'
+    | 'spawn_subagents'
+    | 'phase_error'
+    | 'policy_silence_blocked';
+  actor: 'planner' | 'runner' | 'dispatcher';
+  payload: Record<string, unknown>;
 }
 
 export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatcher {
@@ -142,7 +173,11 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
   }
 
   async shutdown(reason: string): Promise<void> {
-    void reason;
+    this.appendDecisionLog({
+      kind: 'terminate',
+      actor: reason === 'phase_error_circuit' ? 'runner' : 'planner',
+      payload: { reason },
+    });
     // Best-effort cleanup. Stopping a non-existent session is a no-op.
     for (const name of [this.plannerName, this.coderName, this.reviewerName]) {
       try {
@@ -195,6 +230,11 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
       throw new Error('Refusing to reset Planner without force=true (would discard chat context)');
     }
     const name = agent === 'planner' ? this.plannerName : agent === 'coder' ? this.coderName : this.reviewerName;
+    this.appendDecisionLog({
+      kind: 'reset_agent',
+      actor: 'dispatcher',
+      payload: { agent, force: !!opts.force, eagerRestart: !!opts.eagerRestart },
+    });
     try {
       await this.config.manager.stopSession(name);
     } catch (err) {
@@ -233,8 +273,24 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
         })) as SendMessageResult;
       } catch (err2) {
         this.logger.error?.(`[autoloop] ${agent} second attempt failed after reset: ${(err2 as Error).message}`);
-        return { output: '', error: (err2 as Error).message };
+        return { output: '', error: (err2 as Error).message, fatal: true };
       }
+    }
+  }
+
+  /**
+   * Append a structured audit row to `<ledger>/decisions.jsonl`. Best-effort:
+   * any I/O failure is logged but never thrown. Captures terminate, reset,
+   * push-policy mutations, compact triggers, subagent spawns, phase-error
+   * passes, and policy-silence attempts that we rejected.
+   */
+  private appendDecisionLog(entry: Omit<DecisionLogEntry, 'ts'>): void {
+    try {
+      fs.mkdirSync(this.ledgerDir, { recursive: true });
+      const line = JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n';
+      fs.appendFileSync(path.join(this.ledgerDir, 'decisions.jsonl'), line);
+    } catch (err) {
+      this.logger.warn?.(`[autoloop] decisions.jsonl append failed: ${(err as Error).message}`);
     }
   }
 
@@ -296,6 +352,11 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
       `[autoloop/${this.config.runId}] ${agent} context ${pct.toFixed(0)}% ≥ ${threshold}% — auto-compact`,
     );
     this.emit('compact', { agent, percent: pct, threshold });
+    this.appendDecisionLog({
+      kind: 'compact',
+      actor: 'dispatcher',
+      payload: { agent, percent: pct, threshold },
+    });
     try {
       await this.config.manager.compactSession(name, this.compactSummaryFor(agent));
     } catch (err) {
@@ -358,6 +419,11 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
     }
     const effects: PlannerToolEffects = {
       spawnSubagents: async (args) => {
+        this.appendDecisionLog({
+          kind: 'spawn_subagents',
+          actor: 'planner',
+          payload: { args },
+        });
         if (this.config.onSpawnSubagents) {
           await this.config.onSpawnSubagents(args);
         } else {
@@ -377,16 +443,45 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
           'on_stall_30min',
           'on_decision_needed',
         ]);
+        const applied: Record<string, unknown> = {};
+        const silenced_blocked: string[] = [];
         for (const [k, v] of Object.entries(delta)) {
           if (!policyKeys.has(k) || typeof v !== 'object' || v === null) continue;
-          (this.config.pushPolicyRef as unknown as Record<string, unknown>)[k] = v as Record<string, unknown>;
+          // B2: refuse to silence the channels that surface phase errors and
+          // user decisions. Other fields on the same rule still apply, so the
+          // operator can re-target level/channel without going dark.
+          const rule = { ...(v as Record<string, unknown>) };
+          if (UNSILENCEABLE_POLICY_KEYS.has(k) && rule.silent === true) {
+            silenced_blocked.push(k);
+            this.logger.warn?.(`[autoloop] refused to set silent=true on critical policy key ${k}`);
+            delete rule.silent;
+          }
+          (this.config.pushPolicyRef as unknown as Record<string, unknown>)[k] = rule;
+          applied[k] = rule;
+        }
+        if (silenced_blocked.length > 0) {
+          this.appendDecisionLog({
+            kind: 'policy_silence_blocked',
+            actor: 'planner',
+            payload: { keys: silenced_blocked },
+          });
+        }
+        if (Object.keys(applied).length > 0) {
+          this.appendDecisionLog({
+            kind: 'update_push_policy',
+            actor: 'planner',
+            payload: { applied },
+          });
         }
       },
       commitPlanFile: async (file, message) => {
         await this.gitCommit(file, message ?? `autoloop: planner commits ${file}`);
       },
     };
-    const handlerResult = await applyPlannerToolCalls(parsed.calls, effects, env.iter);
+    // After iter_done(N) the run has advanced to iter N+1 in runner state;
+    // any directive Planner emits in response targets the new iter.
+    const nextIter = env.type === 'iter_done' ? env.iter + 1 : env.iter;
+    const handlerResult = await applyPlannerToolCalls(parsed.calls, effects, nextIter);
     for (const errEntry of handlerResult.errors) {
       this.logger.warn?.(`[autoloop] tool '${errEntry.tool}' failed: ${errEntry.error}`);
     }
@@ -427,6 +522,7 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
       path.join(iterDir, 'directive.json'),
       JSON.stringify(
         {
+          schema_version: LEDGER_SCHEMA_VERSION,
           iter: env.iter,
           ts: env.ts,
           ...env.payload,
@@ -462,14 +558,31 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
       .join('\n');
 
     const result = await this.sendWithRecovery('coder', this.coderName, promptText);
+    // A3: subprocess died (recovery retry exhausted). Surface as phase_error
+    // rather than silently masquerading as a "clarification request"; the
+    // runner's circuit breaker can then trip after enough consecutive failures.
+    if (result.fatal) {
+      this.appendDecisionLog({
+        kind: 'phase_error',
+        actor: 'dispatcher',
+        payload: { agent: 'coder', phase: 'send', error: result.error ?? 'unknown' },
+      });
+      return [
+        Msg.phaseError(env.iter, {
+          agent: 'coder',
+          phase: 'send',
+          error: result.error ?? 'unknown send failure',
+        }),
+      ];
+    }
     const replyText = (result.output ?? '').trim();
     const parsed = parseAgentReply(replyText);
     this.emit('coder_reply', parsed.cleaned_reply);
 
     const ic = extractIterComplete(parsed.calls);
     if (!ic) {
-      // No iter_complete emitted — could be a clarification request, or the
-      // Coder bailed. Return a directive_ack so Planner sees it next turn.
+      // No iter_complete emitted — could be a clarification request. Return a
+      // directive_ack so Planner sees it next turn.
       await this.maybeCompact('coder', this.coderName);
       return [
         Msg.directiveAck(env.iter, {
@@ -480,7 +593,10 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
     }
 
     // Persist eval output to ledger.
-    fs.writeFileSync(path.join(iterDir, 'eval_output.json'), JSON.stringify(ic.eval_output, null, 2));
+    fs.writeFileSync(
+      path.join(iterDir, 'eval_output.json'),
+      JSON.stringify({ schema_version: LEDGER_SCHEMA_VERSION, iter: env.iter, eval_output: ic.eval_output }, null, 2),
+    );
     fs.writeFileSync(
       path.join(iterDir, 'coder_summary.txt'),
       `${ic.summary}\n\n--- coder cleaned reply ---\n${parsed.cleaned_reply}\n`,
@@ -500,7 +616,23 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
     // Commit the iteration so Reviewer's git view is clean for the next iter.
     await this.runGit(['git', 'add', '-A']);
     const commitMsg = `autoloop/iter-${env.iter}: ${ic.summary}`.slice(0, 200);
-    await this.runGit(['git', 'commit', '-m', commitMsg]);
+    const commitRes = await this.runGit(['git', 'commit', '-m', commitMsg]);
+    // A6: a non-"nothing to commit" failure (hook reject, signing missing,
+    // index lock) means the next iter's diff would be wrong. Bail to runner.
+    if (commitRes.code !== 0 && !/nothing to commit/i.test(commitRes.out + commitRes.err)) {
+      this.appendDecisionLog({
+        kind: 'phase_error',
+        actor: 'dispatcher',
+        payload: { agent: 'coder', phase: 'git_commit', error: commitRes.err.slice(0, 500) },
+      });
+      return [
+        Msg.phaseError(env.iter, {
+          agent: 'coder',
+          phase: 'git_commit',
+          error: `git commit failed (code=${commitRes.code}): ${commitRes.err.slice(0, 300)}`,
+        }),
+      ];
+    }
 
     await this.maybeCompact('coder', this.coderName);
     return [
@@ -514,6 +646,37 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
 
   // ─── Reviewer ───────────────────────────────────────────────────────────
 
+  /**
+   * Compose the Reviewer's system prompt with a frozen snapshot of
+   * `reviewer_memory.md` appended. Read once at session start; mid-session
+   * edits to the file do NOT take effect until the next Reviewer reset. This
+   * keeps the per-iter prompt prefix stable so Claude's prefix cache hits.
+   */
+  private buildReviewerSystemPrompt(): string {
+    const memoryPath = path.join(this.reviewerSandboxDir, 'reviewer_memory.md');
+    let memory = '';
+    try {
+      if (fs.existsSync(memoryPath)) {
+        memory = fs.readFileSync(memoryPath, 'utf-8').trim();
+      }
+    } catch (err) {
+      this.logger.warn?.(`[autoloop] failed to read reviewer_memory.md: ${(err as Error).message}`);
+    }
+    if (!memory) return this.reviewerSystemPrompt;
+    return [
+      this.reviewerSystemPrompt.trimEnd(),
+      '',
+      '<frozen_memory_snapshot>',
+      memory,
+      '</frozen_memory_snapshot>',
+      '',
+      'The snapshot above was injected into your system prompt at session start',
+      'and is frozen for this Reviewer session. Append new fakery patterns or',
+      'observations to reviewer_memory.md on disk; they will be re-injected on',
+      'the next Reviewer reset, not mid-session.',
+    ].join('\n');
+  }
+
   private async ensureReviewer(): Promise<void> {
     if (this.reviewerStarted) return;
     fs.mkdirSync(this.reviewerSandboxDir, { recursive: true });
@@ -523,7 +686,7 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
       engine: 'claude',
       model: this.reviewerModel,
       permissionMode: 'bypassPermissions',
-      systemPrompt: this.reviewerSystemPrompt,
+      systemPrompt: this.buildReviewerSystemPrompt(),
     });
     this.reviewerStarted = true;
   }
@@ -535,9 +698,11 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
    */
   private stageReviewSandbox(iter: number): void {
     fs.mkdirSync(this.reviewerSandboxDir, { recursive: true });
-    // Wipe top-level files (keep reviewer_memory.md if present).
+    // Wipe top-level files but preserve the Reviewer's cross-iter memory and
+    // append-only audit log (see REVIEWER_SANDBOX_PERSIST). The Reviewer prompt
+    // promises both survive across iters; the wipe used to break the log.
     for (const ent of fs.readdirSync(this.reviewerSandboxDir)) {
-      if (ent === 'reviewer_memory.md') continue;
+      if (REVIEWER_SANDBOX_PERSIST.has(ent)) continue;
       const full = path.join(this.reviewerSandboxDir, ent);
       try {
         fs.rmSync(full, { recursive: true, force: true });
@@ -583,6 +748,20 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
     ].join('\n');
 
     const result = await this.sendWithRecovery('reviewer', this.reviewerName, promptText);
+    if (result.fatal) {
+      this.appendDecisionLog({
+        kind: 'phase_error',
+        actor: 'dispatcher',
+        payload: { agent: 'reviewer', phase: 'send', error: result.error ?? 'unknown' },
+      });
+      return [
+        Msg.phaseError(env.payload.iter, {
+          agent: 'reviewer',
+          phase: 'send',
+          error: result.error ?? 'unknown send failure',
+        }),
+      ];
+    }
     const replyText = (result.output ?? '').trim();
     const parsed = parseAgentReply(replyText);
     this.emit('reviewer_reply', parsed.cleaned_reply);
@@ -618,7 +797,11 @@ export class ClaudeAgentDispatcher extends EventEmitter implements AgentDispatch
     fs.mkdirSync(iterDir, { recursive: true });
     fs.writeFileSync(
       path.join(iterDir, 'verdict.json'),
-      JSON.stringify({ iter, ts: new Date().toISOString(), ...payload }, null, 2),
+      JSON.stringify(
+        { schema_version: LEDGER_SCHEMA_VERSION, iter, ts: new Date().toISOString(), ...payload },
+        null,
+        2,
+      ),
     );
   }
 

--- a/src/autoloop/messages.ts
+++ b/src/autoloop/messages.ts
@@ -87,6 +87,19 @@ export interface TerminatePayload {
   reason: string;
 }
 
+/**
+ * Surfaced when an agent subprocess dies, a phase-bound side effect fails
+ * (e.g., git commit), or any other unrecoverable per-iter error needs to
+ * become visible to the runner instead of being swallowed inside a fake
+ * directive_ack. The runner counts consecutive phase_errors and trips a
+ * circuit-breaker terminate when the configured threshold is reached.
+ */
+export interface PhaseErrorPayload {
+  agent: 'planner' | 'coder' | 'reviewer';
+  phase: string;
+  error: string;
+}
+
 // ─── Discriminated union ─────────────────────────────────────────────────────
 
 export type AutoloopMessageType =
@@ -100,7 +113,8 @@ export type AutoloopMessageType =
   | 'push_user'
   | 'pause'
   | 'resume'
-  | 'terminate';
+  | 'terminate'
+  | 'phase_error';
 
 type PayloadMap = {
   chat: UserChatPayload;
@@ -114,6 +128,7 @@ type PayloadMap = {
   pause: PausePayload;
   resume: ResumePayload;
   terminate: TerminatePayload;
+  phase_error: PhaseErrorPayload;
 };
 
 export type PayloadFor<T extends AutoloopMessageType> = PayloadMap[T];
@@ -141,6 +156,9 @@ const ALLOWED_ROUTES: ReadonlyArray<readonly [AutoloopRole, AutoloopRole, Autolo
   ['planner', 'runner', 'pause'],
   ['planner', 'runner', 'resume'],
   ['planner', 'runner', 'terminate'],
+  ['coder', 'runner', 'phase_error'],
+  ['reviewer', 'runner', 'phase_error'],
+  ['planner', 'runner', 'phase_error'],
 ];
 
 export class AutoloopRoutingError extends Error {
@@ -203,6 +221,8 @@ export const Msg = {
   pause: (iter: number, payload: PausePayload) => envelope(iter, 'planner', 'runner', 'pause', payload),
   resume: (iter: number) => envelope(iter, 'planner', 'runner', 'resume', {}),
   terminate: (iter: number, payload: TerminatePayload) => envelope(iter, 'planner', 'runner', 'terminate', payload),
+  phaseError: (iter: number, payload: PhaseErrorPayload) =>
+    envelope(iter, payload.agent, 'runner', 'phase_error', payload),
 };
 
 // ─── Wire serialisation (for InboxManager transport) ─────────────────────────

--- a/src/autoloop/notify.ts
+++ b/src/autoloop/notify.ts
@@ -22,10 +22,19 @@ import { type Logger, nullLogger } from '../logger.js';
 // Set the following env vars before relying on the matching channel; if a
 // var is unset that channel is silently skipped and the fallback chain moves
 // on. Email (independent SMTP via push-api-skill script) is the final tier
-// regardless of these.
-const WECHAT_RECIPIENT = process.env.AUTOLOOP_WECHAT_RECIPIENT ?? '';
-const WECHAT_ACCOUNT = process.env.AUTOLOOP_WECHAT_ACCOUNT ?? '';
-const WHATSAPP_RECIPIENT = process.env.AUTOLOOP_WHATSAPP_RECIPIENT ?? '';
+// regardless of these. Read at call time (not module load) so the operator
+// can rotate the env without restarting the whole orchestrator.
+function readRecipientEnv(): {
+  wechatRecipient: string;
+  wechatAccount: string;
+  whatsappRecipient: string;
+} {
+  return {
+    wechatRecipient: process.env.AUTOLOOP_WECHAT_RECIPIENT ?? '',
+    wechatAccount: process.env.AUTOLOOP_WECHAT_ACCOUNT ?? '',
+    whatsappRecipient: process.env.AUTOLOOP_WHATSAPP_RECIPIENT ?? '',
+  };
+}
 
 interface RunResult {
   exit_code: number;
@@ -79,7 +88,8 @@ function formatMessage(level: PushLevel, summary: string): string {
 }
 
 async function tryWechat(text: string, logger: Logger): Promise<boolean> {
-  if (!WECHAT_RECIPIENT || !WECHAT_ACCOUNT) {
+  const { wechatRecipient, wechatAccount } = readRecipientEnv();
+  if (!wechatRecipient || !wechatAccount) {
     logger.info?.('[autoloop/notify] wechat skipped: AUTOLOOP_WECHAT_RECIPIENT / AUTOLOOP_WECHAT_ACCOUNT not set');
     return false;
   }
@@ -90,9 +100,9 @@ async function tryWechat(text: string, logger: Logger): Promise<boolean> {
     '--channel',
     'openclaw-weixin',
     '--account',
-    WECHAT_ACCOUNT,
+    wechatAccount,
     '-t',
-    WECHAT_RECIPIENT,
+    wechatRecipient,
     '-m',
     text,
   ]);
@@ -102,21 +112,12 @@ async function tryWechat(text: string, logger: Logger): Promise<boolean> {
 }
 
 async function tryWhatsApp(text: string, logger: Logger): Promise<boolean> {
-  if (!WHATSAPP_RECIPIENT) {
+  const { whatsappRecipient } = readRecipientEnv();
+  if (!whatsappRecipient) {
     logger.info?.('[autoloop/notify] whatsapp skipped: AUTOLOOP_WHATSAPP_RECIPIENT not set');
     return false;
   }
-  const r = await runCmd([
-    'openclaw',
-    'message',
-    'send',
-    '--channel',
-    'whatsapp',
-    '-t',
-    WHATSAPP_RECIPIENT,
-    '-m',
-    text,
-  ]);
+  const r = await runCmd(['openclaw', 'message', 'send', '--channel', 'whatsapp', '-t', whatsappRecipient, '-m', text]);
   if (r.exit_code === 0 && /✅\s*Sent/.test(r.stdout)) return true;
   logger.warn?.(`[autoloop/notify] whatsapp failed: code=${r.exit_code} stderr=${r.stderr.slice(0, 200)}`);
   return false;

--- a/src/autoloop/runner.ts
+++ b/src/autoloop/runner.ts
@@ -13,9 +13,12 @@
 
 import { EventEmitter } from 'node:events';
 import { type AnyAutoloopMessage, AutoloopRoutingError, Msg, validateMessage } from './messages.js';
-import { DEFAULT_PUSH_POLICY, type AutoloopConfig, type AutoloopState } from './types.js';
+import { DEFAULT_PUSH_POLICY, MAX_METRIC_HISTORY, type AutoloopConfig, type AutoloopState } from './types.js';
 
 const MAX_DISPATCH_DEPTH = 64;
+const DEFAULT_PHASE_ERROR_CIRCUIT = 3;
+const DEFAULT_STALL_MS = 30 * 60_000;
+const DEFAULT_STALL_CHECK_MS = 30_000;
 
 /**
  * Events emitted by the runner (string keys, documented payloads):
@@ -31,11 +34,18 @@ export class AutoloopRunner extends EventEmitter {
   state: AutoloopState;
   /** Queue of messages awaiting routing. Drained by the active dispatch loop. */
   private queue: AnyAutoloopMessage[] = [];
+  /**
+   * Holds agent-bound messages that arrived while status === 'paused'.
+   * On `resume`, they are unshifted back onto the queue head in order so
+   * the loop continues exactly where it stopped.
+   */
+  private pausedBuffer: AnyAutoloopMessage[] = [];
   private draining = false;
   private regressionStreak = 0;
   private rejectStreak = 0;
   /** Recent push events for dedup (5 min window). */
   private recentPushes: Array<{ key: string; ts: number }> = [];
+  private stallTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(config: AutoloopConfig) {
     super();
@@ -50,6 +60,10 @@ export class AutoloopRunner extends EventEmitter {
       ledger_dir: config.ledger_dir,
       push_log_count: 0,
       status_reason: null,
+      consecutive_phase_errors: 0,
+      recent_phase_errors: [],
+      metric_history: [],
+      last_activity_at: Date.now(),
     };
   }
 
@@ -57,6 +71,32 @@ export class AutoloopRunner extends EventEmitter {
     await this.config.dispatcher.init?.(this.state);
     // Surface initial state so listeners can render the planning UI.
     this.emit('state', this.state);
+    this.startStallDetector();
+  }
+
+  /** Stop the stall detector; safe to call multiple times. Tests use this. */
+  stop(): void {
+    if (this.stallTimer) {
+      clearInterval(this.stallTimer);
+      this.stallTimer = null;
+    }
+  }
+
+  private startStallDetector(): void {
+    if (this.stallTimer) return;
+    const stallMs = this.config.stallMs ?? DEFAULT_STALL_MS;
+    const intervalMs = this.config.stallCheckIntervalMs ?? DEFAULT_STALL_CHECK_MS;
+    this.stallTimer = setInterval(() => {
+      if (this.state.status !== 'running') return;
+      const idleFor = Date.now() - this.state.last_activity_at;
+      if (idleFor < stallMs) return;
+      // Reuse the policy-push pipeline so dedup applies.
+      void this.firePolicyPush('on_stall_30min', this.state.iter).catch((err) => {
+        this.emit('error', err);
+      });
+    }, intervalMs);
+    // Don't keep node alive solely for stall checking.
+    this.stallTimer?.unref?.();
   }
 
   /** Enqueue a message and drain the queue. Resolves when the queue is idle. */
@@ -101,6 +141,7 @@ export class AutoloopRunner extends EventEmitter {
 
   private async handleOne(env: AnyAutoloopMessage): Promise<void> {
     this.emit('message', env);
+    this.state.last_activity_at = Date.now();
 
     // Runner is the target for a small set of messages — handle them inline.
     if (env.to === 'runner') {
@@ -117,6 +158,12 @@ export class AutoloopRunner extends EventEmitter {
 
     // Everything else goes to the agent dispatcher.
     if (this.state.status === 'terminated') return;
+    // Pause: park agent-bound messages until resume. Runner-bound (resume /
+    // terminate) and user-bound (push) flow through above and are unaffected.
+    if (this.state.status === 'paused') {
+      this.pausedBuffer.push(env);
+      return;
+    }
     const replies = await this.config.dispatcher.deliver(env);
     for (const r of replies) {
       validateMessage(r);
@@ -131,7 +178,7 @@ export class AutoloopRunner extends EventEmitter {
         const req = Msg.reviewRequest(env.iter, {
           iter: env.iter,
           ledger_path: this.config.ledger_dir,
-          prior_metrics: [], // S4 will populate from metric.json
+          prior_metrics: this.state.metric_history.slice(-10),
         });
         this.queue.push(req);
         return;
@@ -147,6 +194,18 @@ export class AutoloopRunner extends EventEmitter {
         if (regression) this.regressionStreak++;
         else this.regressionStreak = 0;
 
+        // A non-error iter resets the phase-error circuit.
+        this.state.consecutive_phase_errors = 0;
+        this.state.recent_phase_errors = [];
+
+        // A7: record metric for prior_metrics on the next review_request.
+        if (typeof v.metric === 'number' && Number.isFinite(v.metric)) {
+          this.state.metric_history.push(v.metric);
+          if (this.state.metric_history.length > MAX_METRIC_HISTORY) {
+            this.state.metric_history.splice(0, this.state.metric_history.length - MAX_METRIC_HISTORY);
+          }
+        }
+
         const done = Msg.iterDone(env.iter, {
           iter: env.iter,
           verdict: v.decision,
@@ -154,10 +213,51 @@ export class AutoloopRunner extends EventEmitter {
           regression,
         });
         this.queue.push(done);
+        // A1: advance iter counter after a verdict is committed. The new iter
+        // becomes addressable for follow-up directives, push events, and SSE.
+        this.state.iter = env.iter + 1;
+        this.emit('state', this.state);
         this.emit('iter_done', { iter: env.iter, verdict: v.decision, metric: v.metric });
         // Trigger policy-based push hooks.
         if (this.regressionStreak >= 2) await this.firePolicyPush('on_metric_regression_2', env.iter);
         if (this.rejectStreak >= 2) await this.firePolicyPush('on_reviewer_reject_2', env.iter);
+        return;
+      }
+      case 'phase_error': {
+        // A3 + C2: track consecutive failures and trip the circuit breaker.
+        const p = env.payload;
+        this.state.consecutive_phase_errors += 1;
+        this.state.recent_phase_errors.push({
+          ts: env.ts,
+          agent: p.agent,
+          phase: p.phase,
+          error: p.error,
+        });
+        if (this.state.recent_phase_errors.length > 5) {
+          this.state.recent_phase_errors.splice(0, this.state.recent_phase_errors.length - 5);
+        }
+        this.emit('state', this.state);
+        this.emit('phase_error', p);
+        await this.firePolicyPush('on_phase_error', env.iter);
+        const circuit = this.config.phaseErrorCircuit ?? DEFAULT_PHASE_ERROR_CIRCUIT;
+        if (this.state.consecutive_phase_errors >= circuit) {
+          const detail = this.state.recent_phase_errors
+            .map((e) => `${e.agent}/${e.phase}: ${e.error.slice(0, 160)}`)
+            .join('\n');
+          this.queue.push(
+            Msg.pushUser(env.iter, {
+              level: 'decision',
+              summary: `phase-error circuit tripped (${this.state.consecutive_phase_errors} consecutive)`,
+              detail,
+              channel: 'both',
+            }),
+          );
+          this.queue.push(
+            Msg.terminate(env.iter, {
+              reason: 'phase_error_circuit',
+            }),
+          );
+        }
         return;
       }
       case 'pause': {
@@ -170,6 +270,12 @@ export class AutoloopRunner extends EventEmitter {
         if (this.state.status === 'paused') {
           this.state.status = 'running';
           this.state.status_reason = null;
+          // Restore parked agent-bound messages at the queue head, preserving
+          // arrival order so the loop continues from where pause caught it.
+          while (this.pausedBuffer.length > 0) {
+            const item = this.pausedBuffer.pop();
+            if (item) this.queue.unshift(item);
+          }
           this.emit('state', this.state);
         }
         return;
@@ -177,6 +283,7 @@ export class AutoloopRunner extends EventEmitter {
       case 'terminate': {
         this.state.status = 'terminated';
         this.state.status_reason = env.payload.reason;
+        this.stop();
         this.emit('state', this.state);
         await this.config.dispatcher.shutdown?.(env.payload.reason);
         this.emit('terminated', env.payload.reason);
@@ -217,5 +324,12 @@ export class AutoloopRunner extends EventEmitter {
         channel: r.channel ?? 'auto',
       }),
     );
+    // When firePolicyPush is called from outside a running drain (e.g. the
+    // stall-detector interval), the queued message would otherwise sit until
+    // the next send(). Kick the drain — the re-entrancy guard makes this safe
+    // when we ARE inside a drain.
+    if (!this.draining) {
+      await this.drain();
+    }
   }
 }

--- a/src/autoloop/types.ts
+++ b/src/autoloop/types.ts
@@ -20,7 +20,24 @@ export interface AutoloopState {
   push_log_count: number;
   /** Last reason set when status flips to terminated/crashed/paused. */
   status_reason: string | null;
+  /**
+   * Phase-error circuit breaker — incremented on every `phase_error` message,
+   * cleared on each successful (non-error) `iter_done`. When it reaches
+   * `AutoloopConfig.phaseErrorCircuit`, the runner auto-terminates.
+   */
+  consecutive_phase_errors: number;
+  /** Recent (≤ 3) phase_error payloads kept around for circuit-trip push detail. */
+  recent_phase_errors: Array<{ ts: string; agent: string; phase: string; error: string }>;
+  /** Recent metric history (most-recent last, capped at MAX_METRIC_HISTORY). */
+  metric_history: number[];
+  /** ms since epoch of the last handled message; used by stall detector. */
+  last_activity_at: number;
 }
+
+/** How many metric points the runner remembers for prior_metrics injection. */
+export const MAX_METRIC_HISTORY = 20;
+/** Schema version stamped onto every ledger artifact (directive/eval/verdict.json). */
+export const LEDGER_SCHEMA_VERSION = 1;
 
 export interface PushPolicyRule {
   silent?: boolean;
@@ -83,4 +100,21 @@ export interface AutoloopConfig {
   notifyUser: (level: PushLevel, summary: string, detail: string | undefined, channel: PushChannel) => Promise<void>;
   /** Agent transport layer (mockable). */
   dispatcher: AgentDispatcher;
+  /**
+   * Phase-error circuit threshold. After this many consecutive `phase_error`
+   * messages the runner auto-terminates with reason `phase_error_circuit`
+   * (and emits a decision-level push first). Default 3.
+   */
+  phaseErrorCircuit?: number;
+  /**
+   * Stall detection wall-clock budget (ms). When no message has been
+   * processed for this long and status is 'running', the runner fires
+   * `on_stall_30min`. Default 30 min.
+   */
+  stallMs?: number;
+  /**
+   * Stall check interval (ms). Default 30 s. Tests pass a smaller value
+   * along with shorter `stallMs` so the assertions complete quickly.
+   */
+  stallCheckIntervalMs?: number;
 }


### PR DESCRIPTION
## Summary

Deep audit of the early-stage autoloop (3-agent: Planner + Coder + Reviewer) surfaced a batch of correctness bugs that made every iter-indexed artifact wrong; this PR fixes them and ships two new capabilities that were on the roadmap.

## Highlights

- **Reviewer frozen-memory injection** — `reviewer_memory.md` is read once at Reviewer-session start and inlined into the system prompt; the snapshot stays constant for the session so Claude's prefix cache hits on every iter.
- **Phase-error circuit breaker** — consecutive subprocess deaths / failed `git commit` / etc. count toward `phaseErrorCircuit` (default 3) and auto-terminate the run with a decision-level push.
- **Stall detector** — `on_stall_30min` actually fires now.
- **`decisions.jsonl` audit trail** — terminate, reset, compact, spawn, policy mutations, phase errors, silence-attempts all land in `<ledger>/decisions.jsonl`.
- **`prior_metrics` history** — Reviewer's "metric improved but eval unchanged" check can finally do its job.

## Behaviour fixes

- `state.iter` advances per `iter_done`; was pinned at 0, so all iter-indexed SSE events / ledger dirs / push summaries had been wrong.
- `pause_loop` enforced — was a no-op despite the manual claiming otherwise.
- Coder / Reviewer subprocess death no longer masquerades as a "clarification request"; it now surfaces as `phase_error` (and feeds the new circuit).
- `stageReviewSandbox` whitelist also keeps `reviewer_log.jsonl` (Reviewer prompt always claimed it persisted; the wipe used to break it).
- Failed `git commit` inside an iter emits `phase_error` instead of writing a stale `iter_artifacts`.
- Planner prompt no longer references a non-existent `src/autoloop/v1/types.ts` and no longer falsely claims `notify_user` is unavailable.

## Guardrails

- `update_push_policy` cannot silence `on_phase_error` / `on_decision_needed`. Attempts get logged in `decisions.jsonl`.
- `firePolicyPush` self-drains when called outside an active drain (so the stall-detector interval's pushes always reach the notifier).
- `notify` reads recipient env vars at call time so operator rotation doesn't require an orchestrator restart.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 523/523 pass (+18 new: 7 dispatcher, 5 notify, 6 runner)
- [x] `npm pack --dry-run` — tarball sane, no leak
- [x] Leak sweep (recipient ids / hostnames / nicknames) — clean
- [ ] After merge: tag `v3.6.0` on main → `gh release create v3.6.0` → publish.yml → npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)