### PR TITLE
docs: add TweetClaw companion plugin example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Documented TweetClaw as a companion OpenClaw plugin for agents that need Claw
+  Orchestrator coding sessions and X/Twitter automation in one workspace.
+
 ## [3.7.1] - 2026-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ curl -fsSL https://raw.githubusercontent.com/Enderfga/claw-orchestrator/main/ins
 
 This installs via npm, registers the plugin in `~/.openclaw/openclaw.json`, and restarts the gateway. See [`skills/references/getting-started.md`](./skills/references/getting-started.md) for the full setup.
 
+#### Pair with X/Twitter automation
+
+Use Claw Orchestrator for coding sessions and install TweetClaw beside it when the same OpenClaw agent needs structured X/Twitter workflows: scrape tweets, search tweets and replies, export followers, look up users, post tweets or replies, upload and download media, send DMs, monitor tweets, deliver webhooks, or run giveaway draws.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+Keep coding-session control in Claw Orchestrator. Keep X/Twitter data and write actions in [TweetClaw](https://github.com/Xquik-dev/tweetclaw), where OpenClaw approval prompts guard write-like calls.
+
 ### As an MCP server (Hermes Agent, Claude Desktop, Cursor, Cline, Continue, Zed, Windsurf, Goose)
 
 Every host that speaks the [Model Context Protocol](https://modelcontextprotocol.io) can pick up the orchestrator's full toolset (41 tools — sessions, council, ultraplan, ultrareview, autoloop, codex, inbox) over stdio.

--- a/skills/references/getting-started.md
+++ b/skills/references/getting-started.md
@@ -27,6 +27,17 @@ openclaw gateway restart
 
 Agents automatically get access to all session, council, and management tools.
 
+### Pair With Domain Plugins
+
+Claw Orchestrator can run coding agents while OpenClaw loads domain plugins for non-code work. For X/Twitter research, monitoring, and account-backed actions, install TweetClaw as a companion plugin:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+Configure TweetClaw credentials as documented in its README before live API calls. Use this pairing when an agent should code through Claw Orchestrator and then search tweets, search tweet replies, export followers, look up users, post tweets or replies, manage media, monitor tweets, send DMs, deliver webhooks, or run giveaway draws through TweetClaw.
+
 ### TypeScript Library
 
 ```typescript


### PR DESCRIPTION
## Summary
- add a README section showing how to pair Claw Orchestrator with TweetClaw when one OpenClaw workspace needs coding sessions plus X/Twitter automation
- mirror the companion-plugin setup in the getting-started skill reference
- add an Unreleased changelog note per the contribution guide

## Validation
- Searched repo content, commit subjects, open/closed PRs, and open/closed issues for TweetClaw, tweetclaw, @xquik/tweetclaw, Xquik-dev/tweetclaw, x-twitter-scraper, Xquik, and xquik. No duplicates found.
- `npm ci --ignore-scripts`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test` after `npm rebuild re2`, because the first run could not load the native re2 binding after lifecycle scripts were disabled
